### PR TITLE
♻️  Rename page to base to avoid clash

### DIFF
--- a/backend/shopping/render/base.templ
+++ b/backend/shopping/render/base.templ
@@ -1,8 +1,9 @@
 package render
 
-templ page() {
+templ base() {
 	<html>
 		<head>
+			<link href="/assets/main.css" rel="stylesheet"/>
 			<script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js"></script>
 			<script>
 				const ws = new WebSocket("http://localhost:8081/reload")

--- a/backend/shopping/render/base_templ.go
+++ b/backend/shopping/render/base_templ.go
@@ -8,7 +8,7 @@ package render
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-func page() templ.Component {
+func base() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -29,7 +29,7 @@ func page() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<html><head><script src=\"https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js\"></script><script>\n\t\t\t\tconst ws = new WebSocket(\"http://localhost:8081/reload\")\n\t\t\t\tws.addEventListener('close', () => {\n\t\t\t\t\tsetTimeout(() => {\n\t\t\t\t\t\twindow.location.reload()\n\t\t\t\t\t}, 500)\n\t\t\t\t})\n\t\t\t</script></head><body>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<html><head><link href=\"/assets/main.css\" rel=\"stylesheet\"><script src=\"https://cdn.jsdelivr.net/npm/htmx.org@2.0.8/dist/htmx.min.js\"></script><script>\n\t\t\t\tconst ws = new WebSocket(\"http://localhost:8081/reload\")\n\t\t\t\tws.addEventListener('close', () => {\n\t\t\t\t\tsetTimeout(() => {\n\t\t\t\t\t\twindow.location.reload()\n\t\t\t\t\t}, 500)\n\t\t\t\t})\n\t\t\t</script></head><body>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/backend/shopping/render/got.templ
+++ b/backend/shopping/render/got.templ
@@ -7,7 +7,7 @@ import (
 
 // GotPage - the main page for the hello server
 templ GotPage() {
-	@page() {
+	@base() {
 		<div>
 			@components.Nav()
 			<div id="title">Got</div>

--- a/backend/shopping/render/got_templ.go
+++ b/backend/shopping/render/got_templ.go
@@ -62,7 +62,7 @@ func GotPage() templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = page().Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = base().Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/backend/shopping/render/shop.templ
+++ b/backend/shopping/render/shop.templ
@@ -7,7 +7,7 @@ import (
 
 // ShopPage - the main page for the hello server
 templ ShopPage() {
-	@page() {
+	@base() {
 		<div>
 			@components.Nav()
 			<div id="title">Shop</div>

--- a/backend/shopping/render/shop_templ.go
+++ b/backend/shopping/render/shop_templ.go
@@ -62,7 +62,7 @@ func ShopPage() templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = page().Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = base().Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/backend/shopping/render/want.templ
+++ b/backend/shopping/render/want.templ
@@ -7,7 +7,7 @@ import (
 
 // WantPage - the main page for the hello server
 templ WantPage() {
-	@page() {
+	@base() {
 		<div>
 			@components.Nav()
 			<div id="title">Want</div>

--- a/backend/shopping/render/want_templ.go
+++ b/backend/shopping/render/want_templ.go
@@ -62,7 +62,7 @@ func WantPage() templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = page().Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = base().Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
Rename the "page" component to "base"
since the name "page" clashes with a package
called "page" that will be introduced in a future
commit.