### PR TITLE
✨ Add `page` package to house page types

### DIFF
--- a/backend/shopping/page/context.go
+++ b/backend/shopping/page/context.go
@@ -1,0 +1,16 @@
+package page
+
+import "net/http"
+
+// Context - represents the context of the current page
+type Context struct {
+	// Path - the URL path of the currently viewed page
+	Path string
+}
+
+// NewContext - returns a page context
+func NewContext(r *http.Request) Context {
+	return Context{
+		Path: r.URL.Path,
+	}
+}


### PR DESCRIPTION
Add `page` package to house page types which will
assist in rendering. These are defined outside of the `render` package since `render/components` will also need them, and `render` already has a dependency on `render/components`.