### PR TITLE
🐛 Fix backend volume mount

### DIFF
--- a/backend/helm/templates/deployment.yaml
+++ b/backend/helm/templates/deployment.yaml
@@ -26,9 +26,9 @@ spec:
               containerPort: 8081
               protocol: TCP
           volumeMounts:
-            - mountPath: /app/local/local.db
+            - mountPath: /app/local
               name: db
       volumes:
         - name: db
           hostPath:
-            path: /home/chris/shoppinglist/local/local.db
+            path: /home/chris/shoppinglist/local


### PR DESCRIPTION
Fix the backend volume mount so that it mounts
the directory that the database is in, rather than mounting the database file directly. When mounting directly, if the database doesn't exist at that time, k8s creates a folder with the same name that the database file should have. This results in the database not being able to bootstrap properly