### PR TITLE
✨ Uplift main dagger module

### DIFF
--- a/.dagger/dagger.gen.go
+++ b/.dagger/dagger.gen.go
@@ -57,16 +57,26 @@ func convertSlice[I any, O any](in []I, f func(I) O) []O {
 }
 
 func (r Shoppinglist) MarshalJSON() ([]byte, error) {
-	var concrete struct{}
+	var concrete struct {
+		Backend  *dagger.Directory
+		Frontend *dagger.Directory
+	}
+	concrete.Backend = r.Backend
+	concrete.Frontend = r.Frontend
 	return json.Marshal(&concrete)
 }
 
 func (r *Shoppinglist) UnmarshalJSON(bs []byte) error {
-	var concrete struct{}
+	var concrete struct {
+		Backend  *dagger.Directory
+		Frontend *dagger.Directory
+	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
 		return err
 	}
+	r.Backend = concrete.Backend
+	r.Frontend = concrete.Frontend
 	return nil
 }
 
@@ -189,24 +199,73 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 	switch parentName {
 	case "Shoppinglist":
 		switch fnName {
+		case "Build":
+			var parent Shoppinglist
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var tag string
+			if inputArgs["tag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tag"]), &tag)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
+				}
+			}
+			var registryPassword *dagger.Secret
+			if inputArgs["registryPassword"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["registryPassword"]), &registryPassword)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registryPassword", err))
+				}
+			}
+			return nil, (*Shoppinglist).Build(&parent, ctx, tag, registryPassword)
+		case "BuildAndDeploy":
+			var parent Shoppinglist
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var registryPassword *dagger.Secret
+			if inputArgs["registryPassword"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["registryPassword"]), &registryPassword)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registryPassword", err))
+				}
+			}
+			var kubeEnv1 *dagger.Secret
+			if inputArgs["kubeEnv1"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kubeEnv1"]), &kubeEnv1)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kubeEnv1", err))
+				}
+			}
+			var kubeEnv2 *dagger.Secret
+			if inputArgs["kubeEnv2"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["kubeEnv2"]), &kubeEnv2)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kubeEnv2", err))
+				}
+			}
+			return nil, (*Shoppinglist).BuildAndDeploy(&parent, ctx, registryPassword, kubeEnv1, kubeEnv2)
 		case "Deploy":
 			var parent Shoppinglist
 			err = json.Unmarshal(parentJSON, &parent)
 			if err != nil {
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
-			var src *dagger.Directory
-			if inputArgs["src"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["src"]), &src)
+			var env string
+			if inputArgs["env"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["env"]), &env)
 				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg src", err))
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg env", err))
 				}
 			}
-			var registryPassword *dagger.Secret
-			if inputArgs["registryPassword"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["registryPassword"]), &registryPassword)
+			var tag string
+			if inputArgs["tag"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["tag"]), &tag)
 				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registryPassword", err))
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg tag", err))
 				}
 			}
 			var kubectlFile *dagger.Secret
@@ -216,8 +275,8 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kubectlFile", err))
 				}
 			}
-			return nil, (*Shoppinglist).Deploy(&parent, ctx, src, registryPassword, kubectlFile)
-		case "DeployBackend":
+			return nil, (*Shoppinglist).Deploy(&parent, ctx, env, tag, kubectlFile)
+		case "":
 			var parent Shoppinglist
 			err = json.Unmarshal(parentJSON, &parent)
 			if err != nil {
@@ -230,49 +289,7 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg src", err))
 				}
 			}
-			var registryPassword *dagger.Secret
-			if inputArgs["registryPassword"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["registryPassword"]), &registryPassword)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registryPassword", err))
-				}
-			}
-			var kubectlFile *dagger.Secret
-			if inputArgs["kubectlFile"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["kubectlFile"]), &kubectlFile)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kubectlFile", err))
-				}
-			}
-			return nil, (*Shoppinglist).DeployBackend(&parent, ctx, src, registryPassword, kubectlFile)
-		case "DeployFrontend":
-			var parent Shoppinglist
-			err = json.Unmarshal(parentJSON, &parent)
-			if err != nil {
-				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
-			}
-			var src *dagger.Directory
-			if inputArgs["src"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["src"]), &src)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg src", err))
-				}
-			}
-			var registryPassword *dagger.Secret
-			if inputArgs["registryPassword"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["registryPassword"]), &registryPassword)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg registryPassword", err))
-				}
-			}
-			var kubectlFile *dagger.Secret
-			if inputArgs["kubectlFile"] != nil {
-				err = json.Unmarshal([]byte(inputArgs["kubectlFile"]), &kubectlFile)
-				if err != nil {
-					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg kubectlFile", err))
-				}
-			}
-			return nil, (*Shoppinglist).DeployFrontend(&parent, ctx, src, registryPassword, kubectlFile)
+			return New(src), nil
 		default:
 			return nil, fmt.Errorf("unknown function %s", fnName)
 		}

--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -17,26 +17,68 @@ package main
 import (
 	"context"
 	"dagger/shoppinglist/internal/dagger"
+	"fmt"
 	"time"
 
+	"dagger.io/dagger/telemetry"
 	"gopkg.in/yaml.v3"
 )
 
-type Shoppinglist struct{}
+type Shoppinglist struct {
+	Backend  *dagger.Directory
+	Frontend *dagger.Directory
+}
 
-// +cache="never"
-func (m *Shoppinglist) Deploy(ctx context.Context,
+func New(
 	// +defaultPath="/"
 	// +ignore=["/local"]
 	src *dagger.Directory,
+) *Shoppinglist {
+	return &Shoppinglist{
+		Backend:  src.Directory("backend"),
+		Frontend: src.Directory("my-app"),
+	}
+}
+
+// +cache="never"
+func (m *Shoppinglist) BuildAndDeploy(
+	ctx context.Context,
 	registryPassword *dagger.Secret,
-	kubectlFile *dagger.Secret,
+	kubeEnv1 *dagger.Secret,
+	kubeEnv2 *dagger.Secret,
 ) error {
-	if err := m.DeployBackend(ctx, src, registryPassword, kubectlFile); err != nil {
+	tag := time.Now().Format("20060102-150405")
+
+	if err := m.Build(ctx, tag, registryPassword); err != nil {
+		return fmt.Errorf("error while building: %w", err)
+	}
+
+	if err := m.Deploy(ctx, "env1", tag, kubeEnv1); err != nil {
+		return fmt.Errorf("error while deploying to kubeEnv1: %w", err)
+	}
+
+	if err := m.Deploy(ctx, "env2", tag, kubeEnv2); err != nil {
+		return fmt.Errorf("error while deploying to kubeEnv2: %w", err)
+	}
+
+	return nil
+}
+
+// +cache="never"
+func (m *Shoppinglist) Deploy(
+	ctx context.Context,
+	env string,
+	tag string,
+	kubectlFile *dagger.Secret,
+) (rerr error) {
+	ctx, span := Tracer().Start(ctx, "deploy: "+env)
+	defer telemetry.EndWithCause(span, &rerr)
+
+	if err := m.deployBackend(ctx, tag, kubectlFile); err != nil {
 		return err
 	}
 
-	if err := m.DeployFrontend(ctx, src, registryPassword, kubectlFile); err != nil {
+	if err := m.deployFrontend(ctx, tag, kubectlFile); err != nil {
 		return err
 	}
 
@@ -44,16 +86,13 @@ func (m *Shoppinglist) Deploy(ctx context.Context,
 }
 
 // +cache="never"
-func (m *Shoppinglist) DeployBackend(ctx context.Context,
-	// +defaultPath="/"
-	// +ignore=["/local"]
-	src *dagger.Directory,
+func (m *Shoppinglist) Build(
+	ctx context.Context,
+	tag string,
 	registryPassword *dagger.Secret,
-	kubectlFile *dagger.Secret,
-) error {
-	backend := src.Directory("backend")
-
-	tag := time.Now().Format("20060102-150405")
+) (rerr error) {
+	ctx, span := Tracer().Start(ctx, "build")
+	defer telemetry.EndWithCause(span, &rerr)
 
 	err := dag.Backend().Publish(
 		ctx,
@@ -65,13 +104,34 @@ func (m *Shoppinglist) DeployBackend(ctx context.Context,
 		return err
 	}
 
+	err = dag.MyApp().Publish(
+		ctx,
+		tag,
+		registryPassword,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Shoppinglist) deployBackend(
+	ctx context.Context,
+	tag string,
+	kubectlFile *dagger.Secret,
+) (rerr error) {
+	ctx, span := Tracer().Start(ctx, "deploy backend")
+	defer telemetry.EndWithCause(span, &rerr)
+
 	valuesYaml, err := makeValuesYaml(tag)
 	if err != nil {
 		return err
 	}
 
 	_, err = dag.Helm().
-		Chart(backend.Directory("helm")).
+		Chart(m.Backend.Directory("helm")).
 		Package().
 		WithKubeconfigSecret(kubectlFile).
 		Install("backend", dagger.HelmPackageInstallOpts{Namespace: "backend", Values: []*dagger.File{valuesYaml}, CreateNamespace: true}).
@@ -84,27 +144,13 @@ func (m *Shoppinglist) DeployBackend(ctx context.Context,
 	return nil
 }
 
-// +cache="never"
-func (m *Shoppinglist) DeployFrontend(ctx context.Context,
-	// +defaultPath="/"
-	// +ignore=["/local"]
-	src *dagger.Directory,
-	registryPassword *dagger.Secret,
+func (m *Shoppinglist) deployFrontend(
+	ctx context.Context,
+	tag string,
 	kubectlFile *dagger.Secret,
-) error {
-	frontend := src.Directory("my-app")
-
-	tag := time.Now().Format("20060102-150405")
-
-	err := dag.MyApp().Publish(
-		ctx,
-		tag,
-		registryPassword,
-	)
-
-	if err != nil {
-		return err
-	}
+) (rerr error) {
+	ctx, span := Tracer().Start(ctx, "deploy frontend")
+	defer telemetry.EndWithCause(span, &rerr)
 
 	valuesYaml, err := makeValuesYaml(tag)
 	if err != nil {
@@ -112,7 +158,7 @@ func (m *Shoppinglist) DeployFrontend(ctx context.Context,
 	}
 
 	_, err = dag.Helm().
-		Chart(frontend.Directory("helm")).
+		Chart(m.Frontend.Directory("helm")).
 		Package().
 		WithKubeconfigSecret(kubectlFile).
 		Install("frontend", dagger.HelmPackageInstallOpts{Namespace: "frontend", Values: []*dagger.File{valuesYaml}, CreateNamespace: true}).

--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+BUILD_REGISTRYPASSWORD=file://./local/GH_API_KEY
+BUILDANDDEPLOY_REGISTRYPASSWORD=file://./local/GH_API_KEY
+BUILDANDDEPLOY_KUBEENV1=file://./local/kubecfg_rpi.yaml
+BUILDANDDEPLOY_KUBEENV2=file://./local/kubecfg_aws0.yaml

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,12 +19,13 @@ jobs:
         uses: dagger/dagger-for-github@8.0.0
         with:
           verb: call
-          args: deploy --registry-password=env://GH_API_KEY --kubectl-file=env://KUBECTL_FILE
+          args: build-and-deploy --registry-password=env://GH_API_KEY --kube-env1=env://KUBECTL_FILE --kube-env2=env://KUBECTL_FILE2
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           version: "0.19.11"
         env:
           GH_API_KEY: ${{ secrets.GH_API_KEY }}
           KUBECTL_FILE: ${{ secrets.KUBECTL_FILE }}
+          KUBECTL2_FILE: ${{ secrets.KUBECTL2_FILE }}
 
 permissions:
   id-token: write


### PR DESCRIPTION
Uplift main dagger module with the following features:
- decouple build and deploy steps, now frontend and backend are built in the `Build` function and frontend and backend are deployed in the `Deploy` function. This makes it easy to test building and deploying separately when running locally.
- move the `backend` and `frontend` source directories to the constructor so they can be resolved and stored once, for other functions to easily consume.
- include `.env` file with dagger secret syntax to reduce function parameters required to run pipeline locally.
- support deployment to a second environment which is the public version of this application for demo purposes.