### PR TITLE
🐛  Use correct env var for kubectl2 config

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: dagger/dagger-for-github@8.0.0
         with:
           verb: call
-          args: build-and-deploy --registry-password=env://GH_API_KEY --kube-env1=env://KUBECTL_FILE --kube-env2=env://KUBECTL_FILE2
+          args: build-and-deploy --registry-password=env://GH_API_KEY --kube-env1=env://KUBECTL_FILE --kube-env2=env://KUBECTL2_FILE
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
           version: "0.19.11"
         env:


### PR DESCRIPTION
The env reference being passed to the dagger
command was wrong