### PR TITLE
♻️  Refactor menu bar and h1 into header

### DIFF
--- a/backend/shopping/assets/main.css
+++ b/backend/shopping/assets/main.css
@@ -5,6 +5,10 @@ html, body {
     margin: 0;
 }
 
+header {
+    margin: 0px 40px;
+}
+
 .nav {
     margin-top: 10px;
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
@@ -52,7 +56,22 @@ html, body {
     width: 100%;
 }
 
-.content {
+.page-menu {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+}
+
+h1 {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    font-weight: 500;
+    color: white;
+    justify-self: flex-start;
+}
+
+#content {
     margin-top: 20px;
     margin-left: 50px;
     margin-right: 50px;

--- a/backend/shopping/render/components/nav.templ
+++ b/backend/shopping/render/components/nav.templ
@@ -20,8 +20,10 @@ var links = []Link{
 templ Nav(pageContext page.Context) {
     <nav class="nav">
         <ul>
-            for _, link := range links {
-                <div class="spacer"></div>
+            for i, link := range links {
+                if i != 0 {
+                    <div class="spacer"></div>
+                }
                 <li
                     if pageContext.Path == link.Link {
                         class="active"
@@ -30,7 +32,6 @@ templ Nav(pageContext page.Context) {
                     <a href={link.Link}>{link.Title}</a>
                 </li>
             }
-            <div class="spacer"></div>
         </ul>
     </nav>
 }

--- a/backend/shopping/render/components/nav_templ.go
+++ b/backend/shopping/render/components/nav_templ.go
@@ -51,49 +51,55 @@ func Nav(pageContext page.Context) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		for _, link := range links {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"spacer\"></div><li")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			if pageContext.Path == link.Link {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, " class=\"active\"")
+		for i, link := range links {
+			if i != 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"spacer\"></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "><a href=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, " <li")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if pageContext.Path == link.Link {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, " class=\"active\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "><a href=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var2 templ.SafeURL
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinURLErrs(link.Link)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `shopping/render/components/nav.templ`, Line: 30, Col: 38}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `shopping/render/components/nav.templ`, Line: 32, Col: 38}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(link.Title)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `shopping/render/components/nav.templ`, Line: 30, Col: 51}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `shopping/render/components/nav.templ`, Line: 32, Col: 51}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</a></li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</a></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div class=\"spacer\"></div></ul></nav>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</ul></nav>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/backend/shopping/render/got.templ
+++ b/backend/shopping/render/got.templ
@@ -9,10 +9,12 @@ import (
 // GotPage - the main page for the hello server
 templ GotPage(pageContext page.Context) {
 	@base() {
-		<div>
+		<header>
 			@components.Nav(pageContext)
-			<div id="title">Got</div>
-		</div>
+			<div class="page-menu">
+				<h1>Got</h1>
+			</div>
+		</header>
 	}
 }
 

--- a/backend/shopping/render/got_templ.go
+++ b/backend/shopping/render/got_templ.go
@@ -49,7 +49,7 @@ func GotPage(pageContext page.Context) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<header>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -57,7 +57,7 @@ func GotPage(pageContext page.Context) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div id=\"title\">Got</div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"page-menu\"><h1>Got</h1></div></header>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/backend/shopping/render/shop.templ
+++ b/backend/shopping/render/shop.templ
@@ -9,10 +9,12 @@ import (
 // ShopPage - the main page for the hello server
 templ ShopPage(pageContext page.Context) {
 	@base() {
-		<div>
+		<header>
 			@components.Nav(pageContext)
-			<div id="title">Shop</div>
-		</div>
+			<div class="page-menu">
+				<h1>Shop</h1>
+			</div>
+		</header>
 	}
 }
 

--- a/backend/shopping/render/shop_templ.go
+++ b/backend/shopping/render/shop_templ.go
@@ -49,7 +49,7 @@ func ShopPage(pageContext page.Context) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<header>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -57,7 +57,7 @@ func ShopPage(pageContext page.Context) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div id=\"title\">Shop</div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"page-menu\"><h1>Shop</h1></div></header>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/backend/shopping/render/want.templ
+++ b/backend/shopping/render/want.templ
@@ -9,14 +9,14 @@ import (
 // WantPage - the main page for the hello server
 templ WantPage(pageContext page.Context, wantItems []page.WantItem) {
 	@base() {
-		<div>
+		<header>
 			@components.Nav(pageContext)
-		</div>
-		
-		<div class="content">
-			<header>
+			<div class="page-menu">
 				<h1>Want</h1>
-			</header>
+			</div>
+		</header>
+		
+		<div id="content">
 			<div class="table-content">
 				<table>
 					<tr class="table-header">
@@ -33,7 +33,7 @@ templ WantPage(pageContext page.Context, wantItems []page.WantItem) {
 					}
 					
 				</table>
-			</div> 
+			</div>
 		</div>
 	}
 }

--- a/backend/shopping/render/want_templ.go
+++ b/backend/shopping/render/want_templ.go
@@ -49,7 +49,7 @@ func WantPage(pageContext page.Context, wantItems []page.WantItem) templ.Compone
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<header>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -57,7 +57,7 @@ func WantPage(pageContext page.Context, wantItems []page.WantItem) templ.Compone
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</div><div class=\"content\"><header><h1>Want</h1></header><div class=\"table-content\"><table><tr class=\"table-header\"><td class=\"col-item\">Item</td><td class=\"col-number\">Number</td><td class=\"col-override\">Override</td></tr>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"page-menu\"><h1>Want</h1></div></header><div id=\"content\"><div class=\"table-content\"><table><tr class=\"table-header\"><td class=\"col-item\">Item</td><td class=\"col-number\">Number</td><td class=\"col-override\">Override</td></tr>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
Refactor menu bar and h1 into top level header
block. This allows the h1 and menu to be
easily aligned to the same margin. At the same
time styles were also tweaked to improve
the look.