### PR TITLE
♻️  Refactor atlas migration image

### DIFF
--- a/backend/.dagger/migrate_image.go
+++ b/backend/.dagger/migrate_image.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 )
 
+// PublishMigrateImage - builds an image that contains the atlas migration tool
+// as well as the new schema that the database needs to be migrated to
 // +cache="never"
 func (m *Backend) PublishMigrateImage(
 	ctx context.Context,
@@ -15,10 +17,12 @@ func (m *Backend) PublishMigrateImage(
 ) error {
 	plats := []dagger.Platform{"linux/arm64", "linux/amd64"}
 
+	toSql := m.RootSrc.File(schemaPath)
+
 	var ctrs []*dagger.Container
 
 	for _, plt := range plats {
-		ctrs = append(ctrs, m.migrateImage(plt))
+		ctrs = append(ctrs, m.migrateImage(plt, toSql))
 	}
 
 	_, err := dag.Container().
@@ -34,15 +38,14 @@ func (m *Backend) PublishMigrateImage(
 	return nil
 }
 
-func (m *Backend) migrateImage(platform dagger.Platform) *dagger.Container {
-	new := m.RootSrc.File(schemaPath)
+func (m *Backend) migrateImage(platform dagger.Platform, toSql *dagger.File) *dagger.Container {
 
 	entrypoint := dag.CurrentModule().Source().File("migrate_image/entrypoint.sh")
 
 	return dag.Container(dagger.ContainerOpts{Platform: platform}).
 		From(atlasVersion).
 		WithWorkdir("/app").
-		WithFile("new.sql", new).
+		WithFile("to.sql", toSql).
 		WithFile("/entrypoint.sh", entrypoint, dagger.ContainerWithFileOpts{Permissions: 444}).
 		WithEntrypoint([]string{"sh", "-c", "/entrypoint.sh"})
 }
@@ -50,16 +53,18 @@ func (m *Backend) migrateImage(platform dagger.Platform) *dagger.Container {
 // TestMigrateImageWithDB - tests that the migrate image works if the DB exists
 // +check
 func (m *Backend) TestMigrateImageWithDB(ctx context.Context) error {
-	schema := dag.CurrentModule().Source().File("golden/schema.sql")
+	fromSql := dag.CurrentModule().Source().File("golden/schema.sql")
+
+	toSql := m.RootSrc.File(schemaPath)
 
 	plt, err := dag.DefaultPlatform(ctx)
 	if err != nil {
 		return err
 	}
 
-	_, err = m.migrateImage(plt).
+	_, err = m.migrateImage(plt, toSql).
 		WithEnvVariable("DATABASE_FILE", "/app/local/local.db").
-		WithFile("/app/local/local.db", dbForSchema(schema)).
+		WithFile("/app/local/local.db", dbForSchema(fromSql)).
 		WithExec(nil, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
 		Stdout(ctx)
 
@@ -69,12 +74,13 @@ func (m *Backend) TestMigrateImageWithDB(ctx context.Context) error {
 // TestMigrateImageNODB - tests that the migrate image works if the DB exists
 // +check
 func (m *Backend) TestMigrateImageNODB(ctx context.Context) error {
+	toSql := m.RootSrc.File(schemaPath)
+
 	plt, err := dag.DefaultPlatform(ctx)
 	if err != nil {
 		return err
 	}
-
-	_, err = m.migrateImage(plt).
+	_, err = m.migrateImage(plt, toSql).
 		WithEnvVariable("DATABASE_FILE", "/app/local/local.db").
 		WithExec(nil, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
 		Stdout(ctx)
@@ -85,12 +91,14 @@ func (m *Backend) TestMigrateImageNODB(ctx context.Context) error {
 // TestMigrateImageNoDBEnv - tests that the migrate image correctly fails if the DATABASE_FILE var isn't present
 // +check
 func (m *Backend) TestMigrateImageNODBEnv(ctx context.Context) error {
+	toSql := m.RootSrc.File(schemaPath)
+
 	plt, err := dag.DefaultPlatform(ctx)
 	if err != nil {
 		return err
 	}
 
-	code, err := m.migrateImage(plt).
+	code, err := m.migrateImage(plt, toSql).
 		WithExec(nil, dagger.ContainerWithExecOpts{UseEntrypoint: true, Expect: dagger.ReturnTypeFailure}).
 		ExitCode(ctx)
 

--- a/backend/.dagger/migrate_image/entrypoint.sh
+++ b/backend/.dagger/migrate_image/entrypoint.sh
@@ -14,5 +14,5 @@ echo "running migration on database"
 
 atlas schema apply \
   --url "sqlite:///${DATABASE_FILE}" \
-  --to file:///app/new.sql \
+  --to file:///app/to.sql \
   --dev-url "sqlite://dev?mode=memory"


### PR DESCRIPTION
Refactor atlas migration image to allow for
the "to" schema to be supplied explicitly.
This does two things:

- makes the api interface of the function a little cleaner, clearly showing how the "to" schema is injected
- will make it easier to pass in a different schema than the one for the backend project. This will be done in a future change to allow the migrate image tests to use a different schema.