### PR TITLE
👷 Add checks for generated sources

### DIFF
--- a/backend/.dagger/dagger.gen.go
+++ b/backend/.dagger/dagger.gen.go
@@ -206,13 +206,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return (*Backend).BuildCheck(&parent, ctx)
-		case "CheckTempl":
+		case "CheckProtos":
 			var parent Backend
 			err = json.Unmarshal(parentJSON, &parent)
 			if err != nil {
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
-			return nil, (*Backend).CheckTempl(&parent, ctx)
+			return nil, (*Backend).CheckProtos(&parent, ctx)
+		case "CheckSqlc":
+			var parent Backend
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return nil, (*Backend).CheckSqlc(&parent, ctx)
 		case "GenerateProtos":
 			var parent Backend
 			err = json.Unmarshal(parentJSON, &parent)

--- a/backend/.dagger/generated.go
+++ b/backend/.dagger/generated.go
@@ -35,13 +35,15 @@ func (m *Backend) GenerateSqlc() *dagger.Changeset {
 }
 
 // +check
-func (m *Backend) CheckTempl(ctx context.Context) error {
-	chgset, err := m.GenerateTempl(ctx)
-	if err != nil {
-		return fmt.Errorf("error generating templates: %w", err)
-	}
+func (m *Backend) CheckProtos(ctx context.Context) error {
+  chgset := m.GenerateProtos()
+  return assertEmpty(ctx, chgset)
+}
 
-	return assertEmpty(ctx, chgset)
+// +check
+func (m *Backend) CheckSqlc(ctx context.Context) error {
+  chgset := m.GenerateSqlc()
+  return assertEmpty(ctx, chgset)
 }
 
 // +generate


### PR DESCRIPTION
Add additional checks for generated sources to ensure that generated code does not get out of sync.