### PR TITLE
♻️  Refactor numeric input class

### DIFF
--- a/backend/shopping/assets/table.css
+++ b/backend/shopping/assets/table.css
@@ -77,11 +77,11 @@ tr:not(:first-child) td {
     min-width: 300px;
 }
 
-.table-header .col-override {
+.table-header .col-numeric-input {
     min-width: 200px
 }
 
-.col-override input {
+.col-numeric-input input {
     width: 70px;
     border-radius: 8px;
     border-style: solid;
@@ -93,7 +93,7 @@ tr:not(:first-child) td {
     font-size: 20px;
 }
 
-.col-override input::-webkit-inner-spin-button {
+.col-numeric-input input::-webkit-inner-spin-button {
     appearance:none;
 }
 

--- a/backend/shopping/render/want.templ
+++ b/backend/shopping/render/want.templ
@@ -26,13 +26,13 @@ templ WantPage(pageContext page.Context, wantItems []page.WantItem) {
 					<tr class="table-header">
 						<td class="col-item">Item</td>
 						<td class="col-number">Number</td>
-						<td class="col-override">Override</td>
+						<td class="col-numeric-input">Override</td>
 					</tr>
 					for _, w := range wantItems {
 					<tr>
 						<td class="col-item">{w.Ingredient}</td>
 						<td class="col-number">{w.Count}</td>
-						<td class="col-override"><input name={fmt.Sprintf("col-override.%d", w.ID)} hx-on:change="setDirty()" value={w.OverrideCount} max="999" type="number"/></td>
+						<td class="col-override col-numeric-input"><input name={fmt.Sprintf("col-override.%d", w.ID)} hx-on:change="setDirty()" value={w.OverrideCount} max="999" type="number"/></td>
 					</tr>
 					}
 					

--- a/backend/shopping/render/want_templ.go
+++ b/backend/shopping/render/want_templ.go
@@ -75,7 +75,7 @@ func WantPage(pageContext page.Context, wantItems []page.WantItem) templ.Compone
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"content\"><div class=\"table-content\"><table><tr class=\"table-header\"><td class=\"col-item\">Item</td><td class=\"col-number\">Number</td><td class=\"col-override\">Override</td></tr>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div id=\"content\"><div class=\"table-content\"><table><tr class=\"table-header\"><td class=\"col-item\">Item</td><td class=\"col-number\">Number</td><td class=\"col-numeric-input\">Override</td></tr>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -106,14 +106,14 @@ func WantPage(pageContext page.Context, wantItems []page.WantItem) templ.Compone
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</td><td class=\"col-override\"><input name=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</td><td class=\"col-override col-numeric-input\"><input name=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var6 string
 					templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("col-override.%d", w.ID))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `shopping/render/want.templ`, Line: 35, Col: 80}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `shopping/render/want.templ`, Line: 35, Col: 98}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 					if templ_7745c5c3_Err != nil {
@@ -126,7 +126,7 @@ func WantPage(pageContext page.Context, wantItems []page.WantItem) templ.Compone
 					var templ_7745c5c3_Var7 string
 					templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(w.OverrideCount)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `shopping/render/want.templ`, Line: 35, Col: 130}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `shopping/render/want.templ`, Line: 35, Col: 148}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 					if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
Refactor numeric input class to use a more generic selector other than `col-override` so that it can be used more generally across other pages that also require numeric inputs.
it does not style the