### PR TITLE
♻️  DRY ingredient fetching logic

### DIFF
--- a/backend/shopping/want.go
+++ b/backend/shopping/want.go
@@ -122,41 +122,9 @@ func parseOverrideColumn(idstr string, value []string) (id int64, ct int64, err 
 }
 
 func (s *Server) wantItems(ctx context.Context) ([]page.WantItem, error) {
-	plan, err := s.plan(ctx)
+	ingredientCounts, ingg, err := s.ingredients(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	meals, err := s.sql.GetMeals(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	mealsmap, err := mealsMap(meals)
-	if err != nil {
-		return nil, err
-	}
-
-	ingg, err := s.sql.GetIngredients(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	smIds := selectedMealIds(plan)
-
-	ingredientCounts := make(map[int64]int32)
-
-	for _, smId := range smIds {
-
-		meal, ok := mealsmap[smId]
-		if !ok {
-			log.Printf("ignored selected meal id %d as it couldnt be found in the meals map", smId)
-			continue
-		}
-
-		for _, igref := range meal.IngredientRefs {
-			ingredientCounts[igref.IngredientId] += igref.Number
-		}
 	}
 
 	var ww []page.WantItem
@@ -171,6 +139,46 @@ func (s *Server) wantItems(ctx context.Context) ([]page.WantItem, error) {
 	}
 
 	return ww, nil
+}
+
+func (s *Server) ingredients(ctx context.Context) (map[int64]int32, []generated.Ingredient, error) {
+	plan, err := s.plan(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	meals, err := s.sql.GetMeals(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	mealsmap, err := mealsMap(meals)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ingg, err := s.sql.GetIngredients(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	smIds := selectedMealIds(plan)
+
+	ingredientCounts := make(map[int64]int32)
+
+	for _, smId := range smIds {
+		meal, ok := mealsmap[smId]
+		if !ok {
+			log.Printf("ignored selected meal id %d as it couldnt be found in the meals map", smId)
+			continue
+		}
+
+		for _, igref := range meal.IngredientRefs {
+			ingredientCounts[igref.IngredientId] += igref.Number
+		}
+	}
+
+	return ingredientCounts, ingg, nil
 }
 
 func (s *Server) plan(ctx context.Context) (*gen.Plan, error) {


### PR DESCRIPTION
DRY ingredient fetching logic to its own routine
to prepare this logic for reuse in future code that needs to fetch ingredients. In paricular is the "got" page which will need to do this.