### PR TITLE
🔇 Avoid warning logs if meal id cant be found

### DIFF
--- a/backend/api/plan.go
+++ b/backend/api/plan.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"log"
 
 	"connectrpc.com/connect"
 	"github.com/chrisjpalmer/shoppinglist/backend/gen"
@@ -115,7 +114,6 @@ func (s *Server) planSummary(ctx context.Context, p *gen.Plan) (*gen.PlanSummary
 
 		meal, ok := mealsmap[smId]
 		if !ok {
-			log.Printf("ignored selected meal id %d as it couldnt be found in the meals map", smId)
 			continue
 		}
 
@@ -141,6 +139,10 @@ func selectedMealIds(p *gen.Plan) []int64 {
 	var meals []int64
 	for _, d := range p.Days {
 		for _, cm := range d.CategoryMeals {
+			if cm.MealId == 0 {
+				// this is a valid case if the plan is uninitialised
+				continue
+			}
 			meals = append(meals, cm.MealId)
 		}
 	}

--- a/backend/shopping/want.go
+++ b/backend/shopping/want.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -169,7 +168,6 @@ func (s *Server) ingredients(ctx context.Context) (map[int64]int32, []generated.
 	for _, smId := range smIds {
 		meal, ok := mealsmap[smId]
 		if !ok {
-			log.Printf("ignored selected meal id %d as it couldnt be found in the meals map", smId)
 			continue
 		}
 
@@ -219,6 +217,10 @@ func selectedMealIds(p *gen.Plan) []int64 {
 	var meals []int64
 	for _, d := range p.Days {
 		for _, cm := range d.CategoryMeals {
+			if cm.MealId == 0 {
+				// this is a valid case if the plan is uninitialised
+				continue
+			}
 			meals = append(meals, cm.MealId)
 		}
 	}


### PR DESCRIPTION
Avoid generating warning logs if the meal id cant
be found, as this is a valid case:
- a meal may be added to a plan then deleted from the db
- a plan may be uninitialised

We filter out the second case for correctness in the change, however the first is still entirely possible and at the moment, we will leave the data in this state even though its technically not valid. Accepting this, we can now remove the warning logs.