### PR TITLE
🎨 Rename `generated` package to `gensql`

### DIFF
--- a/backend/.dagger/generated.go
+++ b/backend/.dagger/generated.go
@@ -31,15 +31,15 @@ func (m *Backend) CheckProtos(ctx context.Context) error {
 // GenerateSqlc - generate sqlc codegen from .sql files
 // +generate
 func (m *Backend) GenerateSqlc() *dagger.Changeset {
-	generated := dag.Container().
+	gensql := dag.Container().
 		From("sqlc/sqlc:1.29.0").
 		WithWorkdir("workdir").
 		WithDirectory("sql", m.Src.Directory("sql")).
 		WithFile("sqlc.yaml", m.Src.File("sqlc.yaml")).
 		WithExec([]string{"generate"}, dagger.ContainerWithExecOpts{UseEntrypoint: true}).
-		Directory("generated")
+		Directory("gensql")
 
-	return m.Src.WithDirectory("generated", generated).Changes(m.Src)
+	return m.Src.WithDirectory("gensql", gensql).Changes(m.Src)
 }
 
 // CheckSqlc - check that the working tree's sqlc generated files are in sync.

--- a/backend/api/ingredients.go
+++ b/backend/api/ingredients.go
@@ -5,7 +5,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/chrisjpalmer/shoppinglist/backend/gen"
-	"github.com/chrisjpalmer/shoppinglist/backend/generated"
+	"github.com/chrisjpalmer/shoppinglist/backend/gensql"
 )
 
 func (s *Server) GetIngredients(ctx context.Context, rq *connect.Request[gen.GetIngredientsRequest]) (*connect.Response[gen.GetIngredientsResponse], error) {
@@ -34,7 +34,7 @@ func (s *Server) CreateIngredient(ctx context.Context, rq *connect.Request[gen.C
 	return connect.NewResponse(&gen.CreateIngredientResponse{IngredientId: id}), nil
 }
 func (s *Server) UpdateIngredient(ctx context.Context, rq *connect.Request[gen.UpdateIngredientRequest]) (*connect.Response[gen.UpdateIngredientResponse], error) {
-	err := s.sql.UpdateIngredient(ctx, generated.UpdateIngredientParams{
+	err := s.sql.UpdateIngredient(ctx, gensql.UpdateIngredientParams{
 		ID:   rq.Msg.Ingredient.Id,
 		Name: rq.Msg.Ingredient.Name,
 	})

--- a/backend/api/meal.go
+++ b/backend/api/meal.go
@@ -5,7 +5,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/chrisjpalmer/shoppinglist/backend/gen"
-	"github.com/chrisjpalmer/shoppinglist/backend/generated"
+	"github.com/chrisjpalmer/shoppinglist/backend/gensql"
 )
 
 func (s *Server) GetMeals(ctx context.Context, rq *connect.Request[gen.GetMealsRequest]) (*connect.Response[gen.GetMealsResponse], error) {
@@ -39,7 +39,7 @@ func (s *Server) CreateMeal(ctx context.Context, rq *connect.Request[gen.CreateM
 		return nil, err
 	}
 
-	id, err := s.sql.CreateMeal(ctx, generated.CreateMealParams{
+	id, err := s.sql.CreateMeal(ctx, gensql.CreateMealParams{
 		Name:        rq.Msg.Meal.Name,
 		Ingredients: igstr,
 		RecipeUrl:   rq.Msg.Meal.RecipeUrl,
@@ -56,7 +56,7 @@ func (s *Server) UpdateMeal(ctx context.Context, rq *connect.Request[gen.UpdateM
 		return nil, err
 	}
 
-	err = s.sql.UpdateMeal(ctx, generated.UpdateMealParams{
+	err = s.sql.UpdateMeal(ctx, gensql.UpdateMealParams{
 		ID:          rq.Msg.Meal.Id,
 		Name:        rq.Msg.Meal.Name,
 		Ingredients: igstr,

--- a/backend/api/plan.go
+++ b/backend/api/plan.go
@@ -8,7 +8,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/chrisjpalmer/shoppinglist/backend/gen"
-	"github.com/chrisjpalmer/shoppinglist/backend/generated"
+	"github.com/chrisjpalmer/shoppinglist/backend/gensql"
 )
 
 func (s *Server) GetPlan(ctx context.Context, rq *connect.Request[gen.GetPlanRequest]) (*connect.Response[gen.GetPlanResponse], error) {
@@ -62,7 +62,7 @@ func (s *Server) UpdatePlan(ctx context.Context, rq *connect.Request[gen.UpdateP
 		return nil, err
 	}
 
-	err = s.sql.UpdatePlan(ctx, generated.UpdatePlanParams{
+	err = s.sql.UpdatePlan(ctx, gensql.UpdatePlanParams{
 		ID:       p.ID,
 		PlanData: pstr,
 	})
@@ -149,7 +149,7 @@ func selectedMealIds(p *gen.Plan) []int64 {
 	return meals
 }
 
-func mealsMap(meals []generated.GetMealsRow) (map[int64]*gen.Meal, error) {
+func mealsMap(meals []gensql.GetMealsRow) (map[int64]*gen.Meal, error) {
 	mealsmap := make(map[int64]*gen.Meal)
 	for _, m := range meals {
 		var igrefs []*gen.IngredientRef

--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/chrisjpalmer/shoppinglist/backend/gen/genconnect"
-	"github.com/chrisjpalmer/shoppinglist/backend/generated"
+	"github.com/chrisjpalmer/shoppinglist/backend/gensql"
 	"github.com/chrisjpalmer/shoppinglist/backend/sql"
 	"github.com/rs/cors"
 	"golang.org/x/net/http2"
@@ -13,7 +13,7 @@ import (
 )
 
 type Server struct {
-	sql *generated.Queries
+	sql *gensql.Queries
 }
 
 func NewServer() (*Server, error) {

--- a/backend/gensql/db.go
+++ b/backend/gensql/db.go
@@ -2,7 +2,7 @@
 // versions:
 //   sqlc v1.29.0
 
-package generated
+package gensql
 
 import (
 	"context"

--- a/backend/gensql/models.go
+++ b/backend/gensql/models.go
@@ -2,7 +2,7 @@
 // versions:
 //   sqlc v1.29.0
 
-package generated
+package gensql
 
 type Ingredient struct {
 	ID                int64

--- a/backend/gensql/query.sql.go
+++ b/backend/gensql/query.sql.go
@@ -3,7 +3,7 @@
 //   sqlc v1.29.0
 // source: query.sql
 
-package generated
+package gensql
 
 import (
 	"context"

--- a/backend/scripts/generate-sqlc.dsh
+++ b/backend/scripts/generate-sqlc.dsh
@@ -1,3 +1,3 @@
 #!/usr/bin/env dagger
 
-. | generate-sqlc | export ./generated
+. | generate-sqlc | export ./gensql

--- a/backend/shopping/server.go
+++ b/backend/shopping/server.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"github.com/a-h/templ"
-	"github.com/chrisjpalmer/shoppinglist/backend/generated"
+	"github.com/chrisjpalmer/shoppinglist/backend/gensql"
 	"github.com/chrisjpalmer/shoppinglist/backend/shopping/page"
 	"github.com/chrisjpalmer/shoppinglist/backend/shopping/render"
 	"github.com/chrisjpalmer/shoppinglist/backend/sql"
@@ -24,7 +24,7 @@ var assets embed.FS
 type Server struct {
 	srv  http.Server
 	done chan struct{}
-	sql  *generated.Queries
+	sql  *gensql.Queries
 }
 
 // NewServer - creates a new server

--- a/backend/shopping/want.go
+++ b/backend/shopping/want.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/a-h/templ"
 	"github.com/chrisjpalmer/shoppinglist/backend/gen"
-	"github.com/chrisjpalmer/shoppinglist/backend/generated"
+	"github.com/chrisjpalmer/shoppinglist/backend/gensql"
 	"github.com/chrisjpalmer/shoppinglist/backend/shopping/page"
 	"github.com/chrisjpalmer/shoppinglist/backend/shopping/render"
 )
@@ -60,7 +60,7 @@ func (m *Server) renderWantPage(w http.ResponseWriter, r *http.Request) {
 
 func (m *Server) saveOverrideColumns(ctx context.Context, ovCt map[int64]int64) error {
 	for id, ct := range ovCt {
-		err := m.sql.UpdateIngredientWantOverrideCount(ctx, generated.UpdateIngredientWantOverrideCountParams{
+		err := m.sql.UpdateIngredientWantOverrideCount(ctx, gensql.UpdateIngredientWantOverrideCountParams{
 			ID:                id,
 			WantOverrideCount: ct,
 		})
@@ -140,7 +140,7 @@ func (s *Server) wantItems(ctx context.Context) ([]page.WantItem, error) {
 	return ww, nil
 }
 
-func (s *Server) ingredients(ctx context.Context) (map[int64]int32, []generated.Ingredient, error) {
+func (s *Server) ingredients(ctx context.Context) (map[int64]int32, []gensql.Ingredient, error) {
 	plan, err := s.plan(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -227,7 +227,7 @@ func selectedMealIds(p *gen.Plan) []int64 {
 	return meals
 }
 
-func mealsMap(meals []generated.GetMealsRow) (map[int64]*gen.Meal, error) {
+func mealsMap(meals []gensql.GetMealsRow) (map[int64]*gen.Meal, error) {
 	mealsmap := make(map[int64]*gen.Meal)
 	for _, m := range meals {
 		var igrefs []*gen.IngredientRef

--- a/backend/sql/db.go
+++ b/backend/sql/db.go
@@ -8,7 +8,7 @@ import (
 
 	_ "embed"
 
-	"github.com/chrisjpalmer/shoppinglist/backend/generated"
+	"github.com/chrisjpalmer/shoppinglist/backend/gensql"
 	_ "github.com/ncruces/go-sqlite3/driver"
 	_ "github.com/ncruces/go-sqlite3/embed"
 )
@@ -16,7 +16,7 @@ import (
 //go:embed schema.sql
 var ddl string
 
-func Connect(ctx context.Context) (*generated.Queries, error) {
+func Connect(ctx context.Context) (*gensql.Queries, error) {
 	dbPath := "local/local.db"
 
 	db, err := sql.Open("sqlite3", fmt.Sprintf("file:%s", dbPath))
@@ -36,7 +36,7 @@ func Connect(ctx context.Context) (*generated.Queries, error) {
 		}
 	}
 
-	return generated.New(db), nil
+	return gensql.New(db), nil
 }
 
 func dbExists(dbPath string) (bool, error) {

--- a/backend/sqlc.yaml
+++ b/backend/sqlc.yaml
@@ -5,5 +5,5 @@ sql:
     schema: "./sql/schema.sql"
     gen:
       go:
-        package: "generated"
-        out: "generated"
+        package: "gensql"
+        out: "gensql"


### PR DESCRIPTION
Rename `generated` package to `gensql` to improve clarity on the code base. The name `generated` is too generic and does not reveal that the generated code pertains to generated sql code from the `sqlc` tool.