### PR TITLE
🚚 Rename generated protobuf code

### DIFF
--- a/backend/.dagger/generated.go
+++ b/backend/.dagger/generated.go
@@ -16,9 +16,9 @@ func (m *Backend) GenerateProtos() *dagger.Changeset {
 		WithDirectory("proto", m.Src.Directory("proto")).
 		WithFiles(".", []*dagger.File{m.Src.File("buf.yaml"), m.Src.File("buf.gen.yaml")}).
 		WithExec([]string{"buf", "generate"}).
-		Directory("gen")
+		Directory("genpb")
 
-	return m.Src.WithDirectory("gen", gen).Changes(m.Src)
+	return m.Src.WithDirectory("genpb", gen).Changes(m.Src)
 }
 
 // CheckProtos - check that the working tree's proto generated files are in sync.

--- a/backend/api/ingredients.go
+++ b/backend/api/ingredients.go
@@ -4,36 +4,36 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	"github.com/chrisjpalmer/shoppinglist/backend/gen"
+	"github.com/chrisjpalmer/shoppinglist/backend/genpb"
 	"github.com/chrisjpalmer/shoppinglist/backend/gensql"
 )
 
-func (s *Server) GetIngredients(ctx context.Context, rq *connect.Request[gen.GetIngredientsRequest]) (*connect.Response[gen.GetIngredientsResponse], error) {
+func (s *Server) GetIngredients(ctx context.Context, rq *connect.Request[genpb.GetIngredientsRequest]) (*connect.Response[genpb.GetIngredientsResponse], error) {
 	ii, err := s.sql.GetIngredients(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	var gii []*gen.Ingredient
+	var gii []*genpb.Ingredient
 
 	for _, i := range ii {
-		gii = append(gii, &gen.Ingredient{
+		gii = append(gii, &genpb.Ingredient{
 			Id:   i.ID,
 			Name: i.Name,
 		})
 	}
 
-	return connect.NewResponse(&gen.GetIngredientsResponse{Ingredients: gii}), nil
+	return connect.NewResponse(&genpb.GetIngredientsResponse{Ingredients: gii}), nil
 }
-func (s *Server) CreateIngredient(ctx context.Context, rq *connect.Request[gen.CreateIngredientRequest]) (*connect.Response[gen.CreateIngredientResponse], error) {
+func (s *Server) CreateIngredient(ctx context.Context, rq *connect.Request[genpb.CreateIngredientRequest]) (*connect.Response[genpb.CreateIngredientResponse], error) {
 	id, err := s.sql.CreateIngredient(ctx, rq.Msg.Ingredient.Name)
 	if err != nil {
 		return nil, err
 	}
 
-	return connect.NewResponse(&gen.CreateIngredientResponse{IngredientId: id}), nil
+	return connect.NewResponse(&genpb.CreateIngredientResponse{IngredientId: id}), nil
 }
-func (s *Server) UpdateIngredient(ctx context.Context, rq *connect.Request[gen.UpdateIngredientRequest]) (*connect.Response[gen.UpdateIngredientResponse], error) {
+func (s *Server) UpdateIngredient(ctx context.Context, rq *connect.Request[genpb.UpdateIngredientRequest]) (*connect.Response[genpb.UpdateIngredientResponse], error) {
 	err := s.sql.UpdateIngredient(ctx, gensql.UpdateIngredientParams{
 		ID:   rq.Msg.Ingredient.Id,
 		Name: rq.Msg.Ingredient.Name,
@@ -42,13 +42,13 @@ func (s *Server) UpdateIngredient(ctx context.Context, rq *connect.Request[gen.U
 		return nil, err
 	}
 
-	return connect.NewResponse(&gen.UpdateIngredientResponse{}), nil
+	return connect.NewResponse(&genpb.UpdateIngredientResponse{}), nil
 }
-func (s *Server) DeleteIngredient(ctx context.Context, rq *connect.Request[gen.DeleteIngredientRequest]) (*connect.Response[gen.DeleteIngredientResponse], error) {
+func (s *Server) DeleteIngredient(ctx context.Context, rq *connect.Request[genpb.DeleteIngredientRequest]) (*connect.Response[genpb.DeleteIngredientResponse], error) {
 	err := s.sql.DeleteIngredient(ctx, rq.Msg.IngredientId)
 	if err != nil {
 		return nil, err
 	}
 
-	return connect.NewResponse(&gen.DeleteIngredientResponse{}), nil
+	return connect.NewResponse(&genpb.DeleteIngredientResponse{}), nil
 }

--- a/backend/api/meal.go
+++ b/backend/api/meal.go
@@ -4,26 +4,26 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	"github.com/chrisjpalmer/shoppinglist/backend/gen"
+	"github.com/chrisjpalmer/shoppinglist/backend/genpb"
 	"github.com/chrisjpalmer/shoppinglist/backend/gensql"
 )
 
-func (s *Server) GetMeals(ctx context.Context, rq *connect.Request[gen.GetMealsRequest]) (*connect.Response[gen.GetMealsResponse], error) {
+func (s *Server) GetMeals(ctx context.Context, rq *connect.Request[genpb.GetMealsRequest]) (*connect.Response[genpb.GetMealsResponse], error) {
 	mm, err := s.sql.GetMeals(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	var gmm []*gen.Meal
+	var gmm []*genpb.Meal
 
 	for _, m := range mm {
-		var ig []*gen.IngredientRef
+		var ig []*genpb.IngredientRef
 		err := unmarshalJSON(m.Ingredients, &ig)
 		if err != nil {
 			return nil, err
 		}
 
-		gmm = append(gmm, &gen.Meal{
+		gmm = append(gmm, &genpb.Meal{
 			Id:             m.ID,
 			Name:           m.Name,
 			IngredientRefs: ig,
@@ -31,9 +31,9 @@ func (s *Server) GetMeals(ctx context.Context, rq *connect.Request[gen.GetMealsR
 		})
 	}
 
-	return connect.NewResponse(&gen.GetMealsResponse{Meals: gmm}), nil
+	return connect.NewResponse(&genpb.GetMealsResponse{Meals: gmm}), nil
 }
-func (s *Server) CreateMeal(ctx context.Context, rq *connect.Request[gen.CreateMealRequest]) (*connect.Response[gen.CreateMealResponse], error) {
+func (s *Server) CreateMeal(ctx context.Context, rq *connect.Request[genpb.CreateMealRequest]) (*connect.Response[genpb.CreateMealResponse], error) {
 	igstr, err := marshalJSON(rq.Msg.Meal.IngredientRefs)
 	if err != nil {
 		return nil, err
@@ -48,9 +48,9 @@ func (s *Server) CreateMeal(ctx context.Context, rq *connect.Request[gen.CreateM
 		return nil, err
 	}
 
-	return connect.NewResponse(&gen.CreateMealResponse{MealId: id}), nil
+	return connect.NewResponse(&genpb.CreateMealResponse{MealId: id}), nil
 }
-func (s *Server) UpdateMeal(ctx context.Context, rq *connect.Request[gen.UpdateMealRequest]) (*connect.Response[gen.UpdateMealResponse], error) {
+func (s *Server) UpdateMeal(ctx context.Context, rq *connect.Request[genpb.UpdateMealRequest]) (*connect.Response[genpb.UpdateMealResponse], error) {
 	igstr, err := marshalJSON(rq.Msg.Meal.IngredientRefs)
 	if err != nil {
 		return nil, err
@@ -66,13 +66,13 @@ func (s *Server) UpdateMeal(ctx context.Context, rq *connect.Request[gen.UpdateM
 		return nil, err
 	}
 
-	return connect.NewResponse(&gen.UpdateMealResponse{}), nil
+	return connect.NewResponse(&genpb.UpdateMealResponse{}), nil
 }
-func (s *Server) DeleteMeal(ctx context.Context, rq *connect.Request[gen.DeleteMealRequest]) (*connect.Response[gen.DeleteMealResponse], error) {
+func (s *Server) DeleteMeal(ctx context.Context, rq *connect.Request[genpb.DeleteMealRequest]) (*connect.Response[genpb.DeleteMealResponse], error) {
 	err := s.sql.DeleteMeal(ctx, rq.Msg.MealId)
 	if err != nil {
 		return nil, err
 	}
 
-	return connect.NewResponse(&gen.DeleteMealResponse{}), nil
+	return connect.NewResponse(&genpb.DeleteMealResponse{}), nil
 }

--- a/backend/api/plan.go
+++ b/backend/api/plan.go
@@ -7,11 +7,11 @@ import (
 	"errors"
 
 	"connectrpc.com/connect"
-	"github.com/chrisjpalmer/shoppinglist/backend/gen"
+	"github.com/chrisjpalmer/shoppinglist/backend/genpb"
 	"github.com/chrisjpalmer/shoppinglist/backend/gensql"
 )
 
-func (s *Server) GetPlan(ctx context.Context, rq *connect.Request[gen.GetPlanRequest]) (*connect.Response[gen.GetPlanResponse], error) {
+func (s *Server) GetPlan(ctx context.Context, rq *connect.Request[genpb.GetPlanRequest]) (*connect.Response[genpb.GetPlanResponse], error) {
 	p, err := s.sql.GetPlan(ctx)
 
 	if errors.Is(err, sql.ErrNoRows) {
@@ -20,14 +20,14 @@ func (s *Server) GetPlan(ctx context.Context, rq *connect.Request[gen.GetPlanReq
 			return nil, err
 		}
 
-		return connect.NewResponse(&gen.GetPlanResponse{Plan: gp}), nil
+		return connect.NewResponse(&genpb.GetPlanResponse{Plan: gp}), nil
 	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	var gp gen.Plan
+	var gp genpb.Plan
 	err = unmarshalJSON(p.PlanData, &gp)
 	if err != nil {
 		return nil, err
@@ -38,10 +38,10 @@ func (s *Server) GetPlan(ctx context.Context, rq *connect.Request[gen.GetPlanReq
 		return nil, err
 	}
 
-	return connect.NewResponse(&gen.GetPlanResponse{Plan: &gp, PlanSummary: sum}), nil
+	return connect.NewResponse(&genpb.GetPlanResponse{Plan: &gp, PlanSummary: sum}), nil
 }
 
-func (s *Server) UpdatePlan(ctx context.Context, rq *connect.Request[gen.UpdatePlanRequest]) (*connect.Response[gen.UpdatePlanResponse], error) {
+func (s *Server) UpdatePlan(ctx context.Context, rq *connect.Request[genpb.UpdatePlanRequest]) (*connect.Response[genpb.UpdatePlanResponse], error) {
 	p, err := s.sql.GetPlan(ctx)
 	if err != nil {
 		return nil, err
@@ -71,10 +71,10 @@ func (s *Server) UpdatePlan(ctx context.Context, rq *connect.Request[gen.UpdateP
 		return nil, err
 	}
 
-	return connect.NewResponse(&gen.UpdatePlanResponse{}), nil
+	return connect.NewResponse(&genpb.UpdatePlanResponse{}), nil
 }
 
-func (s *Server) createEmptyPlan(ctx context.Context) (*gen.Plan, error) {
+func (s *Server) createEmptyPlan(ctx context.Context) (*genpb.Plan, error) {
 	p := emptyPlan()
 
 	ps, err := marshalJSON(&p)
@@ -90,7 +90,7 @@ func (s *Server) createEmptyPlan(ctx context.Context) (*gen.Plan, error) {
 	return &p, nil
 }
 
-func (s *Server) planSummary(ctx context.Context, p *gen.Plan) (*gen.PlanSummary, error) {
+func (s *Server) planSummary(ctx context.Context, p *genpb.Plan) (*genpb.PlanSummary, error) {
 	meals, err := s.sql.GetMeals(ctx)
 	if err != nil {
 		return nil, err
@@ -122,20 +122,20 @@ func (s *Server) planSummary(ctx context.Context, p *gen.Plan) (*gen.PlanSummary
 		}
 	}
 
-	var igrefs []*gen.IngredientRef
+	var igrefs []*genpb.IngredientRef
 	for _, ing := range ingg {
 		ct := ingredientCounts[ing.ID]
 		if ct > 0 {
-			igrefs = append(igrefs, &gen.IngredientRef{IngredientId: ing.ID, Number: ct})
+			igrefs = append(igrefs, &genpb.IngredientRef{IngredientId: ing.ID, Number: ct})
 		}
 	}
 
-	return &gen.PlanSummary{
+	return &genpb.PlanSummary{
 		IngredientRef: igrefs,
 	}, nil
 }
 
-func selectedMealIds(p *gen.Plan) []int64 {
+func selectedMealIds(p *genpb.Plan) []int64 {
 	var meals []int64
 	for _, d := range p.Days {
 		for _, cm := range d.CategoryMeals {
@@ -149,17 +149,17 @@ func selectedMealIds(p *gen.Plan) []int64 {
 	return meals
 }
 
-func mealsMap(meals []gensql.GetMealsRow) (map[int64]*gen.Meal, error) {
-	mealsmap := make(map[int64]*gen.Meal)
+func mealsMap(meals []gensql.GetMealsRow) (map[int64]*genpb.Meal, error) {
+	mealsmap := make(map[int64]*genpb.Meal)
 	for _, m := range meals {
-		var igrefs []*gen.IngredientRef
+		var igrefs []*genpb.IngredientRef
 
 		err := unmarshalJSON(m.Ingredients, &igrefs)
 		if err != nil {
 			return nil, err
 		}
 
-		mealsmap[m.ID] = &gen.Meal{
+		mealsmap[m.ID] = &genpb.Meal{
 			Name:           m.Name,
 			Id:             m.ID,
 			IngredientRefs: igrefs,
@@ -170,17 +170,17 @@ func mealsMap(meals []gensql.GetMealsRow) (map[int64]*gen.Meal, error) {
 	return mealsmap, nil
 }
 
-func emptyPlan() gen.Plan {
-	var days []*gen.Day
+func emptyPlan() genpb.Plan {
+	var days []*genpb.Day
 	for range 7 {
-		days = append(days, &gen.Day{
-			CategoryMeals: []*gen.CategoryMeal{
+		days = append(days, &genpb.Day{
+			CategoryMeals: []*genpb.CategoryMeal{
 				// 0 = lunch, 1 = dinner, 2 = snack
-				{Category: gen.Category_CATEGORY_LUNCH}, {Category: gen.Category_CATEGORY_DINNER}, {Category: gen.Category_CATEGORY_SNACK},
+				{Category: genpb.Category_CATEGORY_LUNCH}, {Category: genpb.Category_CATEGORY_DINNER}, {Category: genpb.Category_CATEGORY_SNACK},
 			},
 		})
 	}
-	return gen.Plan{
+	return genpb.Plan{
 		Days: days,
 	}
 }

--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/chrisjpalmer/shoppinglist/backend/gen/genconnect"
+	"github.com/chrisjpalmer/shoppinglist/backend/genpb/genpbconnect"
 	"github.com/chrisjpalmer/shoppinglist/backend/gensql"
 	"github.com/chrisjpalmer/shoppinglist/backend/sql"
 	"github.com/rs/cors"
@@ -27,7 +27,7 @@ func NewServer() (*Server, error) {
 
 func (s *Server) Listen() error {
 	mux := http.NewServeMux()
-	path, handler := genconnect.NewShoppingListServiceHandler(s)
+	path, handler := genpbconnect.NewShoppingListServiceHandler(s)
 	mux.Handle(path, handler)
 
 	return http.ListenAndServe(":8080", h2c.NewHandler(cors.AllowAll().Handler(mux), &http2.Server{}))

--- a/backend/buf.gen.yaml
+++ b/backend/buf.gen.yaml
@@ -3,13 +3,13 @@ managed:
   enabled: true
   override:
     - file_option: go_package_prefix
-      value: github.com/chrisjpalmer/shoppinglist/backend/gen
+      value: github.com/chrisjpalmer/shoppinglist/backend/genpb
 plugins:
   - remote: buf.build/protocolbuffers/go
-    out: gen
+    out: genpb
     opt: paths=source_relative
   - remote: buf.build/connectrpc/go
-    out: gen
+    out: genpb
     opt: paths=source_relative
 inputs:
   - directory: proto

--- a/backend/genpb/genpbconnect/shopping_list_service.connect.go
+++ b/backend/genpb/genpbconnect/shopping_list_service.connect.go
@@ -2,13 +2,13 @@
 //
 // Source: shopping_list_service.proto
 
-package genconnect
+package genpbconnect
 
 import (
 	connect "connectrpc.com/connect"
 	context "context"
 	errors "errors"
-	gen "github.com/chrisjpalmer/shoppinglist/backend/gen"
+	genpb "github.com/chrisjpalmer/shoppinglist/backend/genpb"
 	http "net/http"
 	strings "strings"
 )
@@ -68,17 +68,17 @@ const (
 // ShoppingListServiceClient is a client for the ShoppingListService service.
 type ShoppingListServiceClient interface {
 	// plan
-	GetPlan(context.Context, *connect.Request[gen.GetPlanRequest]) (*connect.Response[gen.GetPlanResponse], error)
-	UpdatePlan(context.Context, *connect.Request[gen.UpdatePlanRequest]) (*connect.Response[gen.UpdatePlanResponse], error)
+	GetPlan(context.Context, *connect.Request[genpb.GetPlanRequest]) (*connect.Response[genpb.GetPlanResponse], error)
+	UpdatePlan(context.Context, *connect.Request[genpb.UpdatePlanRequest]) (*connect.Response[genpb.UpdatePlanResponse], error)
 	// meals
-	GetMeals(context.Context, *connect.Request[gen.GetMealsRequest]) (*connect.Response[gen.GetMealsResponse], error)
-	CreateMeal(context.Context, *connect.Request[gen.CreateMealRequest]) (*connect.Response[gen.CreateMealResponse], error)
-	UpdateMeal(context.Context, *connect.Request[gen.UpdateMealRequest]) (*connect.Response[gen.UpdateMealResponse], error)
-	DeleteMeal(context.Context, *connect.Request[gen.DeleteMealRequest]) (*connect.Response[gen.DeleteMealResponse], error)
-	GetIngredients(context.Context, *connect.Request[gen.GetIngredientsRequest]) (*connect.Response[gen.GetIngredientsResponse], error)
-	CreateIngredient(context.Context, *connect.Request[gen.CreateIngredientRequest]) (*connect.Response[gen.CreateIngredientResponse], error)
-	UpdateIngredient(context.Context, *connect.Request[gen.UpdateIngredientRequest]) (*connect.Response[gen.UpdateIngredientResponse], error)
-	DeleteIngredient(context.Context, *connect.Request[gen.DeleteIngredientRequest]) (*connect.Response[gen.DeleteIngredientResponse], error)
+	GetMeals(context.Context, *connect.Request[genpb.GetMealsRequest]) (*connect.Response[genpb.GetMealsResponse], error)
+	CreateMeal(context.Context, *connect.Request[genpb.CreateMealRequest]) (*connect.Response[genpb.CreateMealResponse], error)
+	UpdateMeal(context.Context, *connect.Request[genpb.UpdateMealRequest]) (*connect.Response[genpb.UpdateMealResponse], error)
+	DeleteMeal(context.Context, *connect.Request[genpb.DeleteMealRequest]) (*connect.Response[genpb.DeleteMealResponse], error)
+	GetIngredients(context.Context, *connect.Request[genpb.GetIngredientsRequest]) (*connect.Response[genpb.GetIngredientsResponse], error)
+	CreateIngredient(context.Context, *connect.Request[genpb.CreateIngredientRequest]) (*connect.Response[genpb.CreateIngredientResponse], error)
+	UpdateIngredient(context.Context, *connect.Request[genpb.UpdateIngredientRequest]) (*connect.Response[genpb.UpdateIngredientResponse], error)
+	DeleteIngredient(context.Context, *connect.Request[genpb.DeleteIngredientRequest]) (*connect.Response[genpb.DeleteIngredientResponse], error)
 }
 
 // NewShoppingListServiceClient constructs a client for the ShoppingListService service. By default,
@@ -90,63 +90,63 @@ type ShoppingListServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewShoppingListServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) ShoppingListServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
-	shoppingListServiceMethods := gen.File_shopping_list_service_proto.Services().ByName("ShoppingListService").Methods()
+	shoppingListServiceMethods := genpb.File_shopping_list_service_proto.Services().ByName("ShoppingListService").Methods()
 	return &shoppingListServiceClient{
-		getPlan: connect.NewClient[gen.GetPlanRequest, gen.GetPlanResponse](
+		getPlan: connect.NewClient[genpb.GetPlanRequest, genpb.GetPlanResponse](
 			httpClient,
 			baseURL+ShoppingListServiceGetPlanProcedure,
 			connect.WithSchema(shoppingListServiceMethods.ByName("GetPlan")),
 			connect.WithClientOptions(opts...),
 		),
-		updatePlan: connect.NewClient[gen.UpdatePlanRequest, gen.UpdatePlanResponse](
+		updatePlan: connect.NewClient[genpb.UpdatePlanRequest, genpb.UpdatePlanResponse](
 			httpClient,
 			baseURL+ShoppingListServiceUpdatePlanProcedure,
 			connect.WithSchema(shoppingListServiceMethods.ByName("UpdatePlan")),
 			connect.WithClientOptions(opts...),
 		),
-		getMeals: connect.NewClient[gen.GetMealsRequest, gen.GetMealsResponse](
+		getMeals: connect.NewClient[genpb.GetMealsRequest, genpb.GetMealsResponse](
 			httpClient,
 			baseURL+ShoppingListServiceGetMealsProcedure,
 			connect.WithSchema(shoppingListServiceMethods.ByName("GetMeals")),
 			connect.WithClientOptions(opts...),
 		),
-		createMeal: connect.NewClient[gen.CreateMealRequest, gen.CreateMealResponse](
+		createMeal: connect.NewClient[genpb.CreateMealRequest, genpb.CreateMealResponse](
 			httpClient,
 			baseURL+ShoppingListServiceCreateMealProcedure,
 			connect.WithSchema(shoppingListServiceMethods.ByName("CreateMeal")),
 			connect.WithClientOptions(opts...),
 		),
-		updateMeal: connect.NewClient[gen.UpdateMealRequest, gen.UpdateMealResponse](
+		updateMeal: connect.NewClient[genpb.UpdateMealRequest, genpb.UpdateMealResponse](
 			httpClient,
 			baseURL+ShoppingListServiceUpdateMealProcedure,
 			connect.WithSchema(shoppingListServiceMethods.ByName("UpdateMeal")),
 			connect.WithClientOptions(opts...),
 		),
-		deleteMeal: connect.NewClient[gen.DeleteMealRequest, gen.DeleteMealResponse](
+		deleteMeal: connect.NewClient[genpb.DeleteMealRequest, genpb.DeleteMealResponse](
 			httpClient,
 			baseURL+ShoppingListServiceDeleteMealProcedure,
 			connect.WithSchema(shoppingListServiceMethods.ByName("DeleteMeal")),
 			connect.WithClientOptions(opts...),
 		),
-		getIngredients: connect.NewClient[gen.GetIngredientsRequest, gen.GetIngredientsResponse](
+		getIngredients: connect.NewClient[genpb.GetIngredientsRequest, genpb.GetIngredientsResponse](
 			httpClient,
 			baseURL+ShoppingListServiceGetIngredientsProcedure,
 			connect.WithSchema(shoppingListServiceMethods.ByName("GetIngredients")),
 			connect.WithClientOptions(opts...),
 		),
-		createIngredient: connect.NewClient[gen.CreateIngredientRequest, gen.CreateIngredientResponse](
+		createIngredient: connect.NewClient[genpb.CreateIngredientRequest, genpb.CreateIngredientResponse](
 			httpClient,
 			baseURL+ShoppingListServiceCreateIngredientProcedure,
 			connect.WithSchema(shoppingListServiceMethods.ByName("CreateIngredient")),
 			connect.WithClientOptions(opts...),
 		),
-		updateIngredient: connect.NewClient[gen.UpdateIngredientRequest, gen.UpdateIngredientResponse](
+		updateIngredient: connect.NewClient[genpb.UpdateIngredientRequest, genpb.UpdateIngredientResponse](
 			httpClient,
 			baseURL+ShoppingListServiceUpdateIngredientProcedure,
 			connect.WithSchema(shoppingListServiceMethods.ByName("UpdateIngredient")),
 			connect.WithClientOptions(opts...),
 		),
-		deleteIngredient: connect.NewClient[gen.DeleteIngredientRequest, gen.DeleteIngredientResponse](
+		deleteIngredient: connect.NewClient[genpb.DeleteIngredientRequest, genpb.DeleteIngredientResponse](
 			httpClient,
 			baseURL+ShoppingListServiceDeleteIngredientProcedure,
 			connect.WithSchema(shoppingListServiceMethods.ByName("DeleteIngredient")),
@@ -157,82 +157,82 @@ func NewShoppingListServiceClient(httpClient connect.HTTPClient, baseURL string,
 
 // shoppingListServiceClient implements ShoppingListServiceClient.
 type shoppingListServiceClient struct {
-	getPlan          *connect.Client[gen.GetPlanRequest, gen.GetPlanResponse]
-	updatePlan       *connect.Client[gen.UpdatePlanRequest, gen.UpdatePlanResponse]
-	getMeals         *connect.Client[gen.GetMealsRequest, gen.GetMealsResponse]
-	createMeal       *connect.Client[gen.CreateMealRequest, gen.CreateMealResponse]
-	updateMeal       *connect.Client[gen.UpdateMealRequest, gen.UpdateMealResponse]
-	deleteMeal       *connect.Client[gen.DeleteMealRequest, gen.DeleteMealResponse]
-	getIngredients   *connect.Client[gen.GetIngredientsRequest, gen.GetIngredientsResponse]
-	createIngredient *connect.Client[gen.CreateIngredientRequest, gen.CreateIngredientResponse]
-	updateIngredient *connect.Client[gen.UpdateIngredientRequest, gen.UpdateIngredientResponse]
-	deleteIngredient *connect.Client[gen.DeleteIngredientRequest, gen.DeleteIngredientResponse]
+	getPlan          *connect.Client[genpb.GetPlanRequest, genpb.GetPlanResponse]
+	updatePlan       *connect.Client[genpb.UpdatePlanRequest, genpb.UpdatePlanResponse]
+	getMeals         *connect.Client[genpb.GetMealsRequest, genpb.GetMealsResponse]
+	createMeal       *connect.Client[genpb.CreateMealRequest, genpb.CreateMealResponse]
+	updateMeal       *connect.Client[genpb.UpdateMealRequest, genpb.UpdateMealResponse]
+	deleteMeal       *connect.Client[genpb.DeleteMealRequest, genpb.DeleteMealResponse]
+	getIngredients   *connect.Client[genpb.GetIngredientsRequest, genpb.GetIngredientsResponse]
+	createIngredient *connect.Client[genpb.CreateIngredientRequest, genpb.CreateIngredientResponse]
+	updateIngredient *connect.Client[genpb.UpdateIngredientRequest, genpb.UpdateIngredientResponse]
+	deleteIngredient *connect.Client[genpb.DeleteIngredientRequest, genpb.DeleteIngredientResponse]
 }
 
 // GetPlan calls ShoppingListService.GetPlan.
-func (c *shoppingListServiceClient) GetPlan(ctx context.Context, req *connect.Request[gen.GetPlanRequest]) (*connect.Response[gen.GetPlanResponse], error) {
+func (c *shoppingListServiceClient) GetPlan(ctx context.Context, req *connect.Request[genpb.GetPlanRequest]) (*connect.Response[genpb.GetPlanResponse], error) {
 	return c.getPlan.CallUnary(ctx, req)
 }
 
 // UpdatePlan calls ShoppingListService.UpdatePlan.
-func (c *shoppingListServiceClient) UpdatePlan(ctx context.Context, req *connect.Request[gen.UpdatePlanRequest]) (*connect.Response[gen.UpdatePlanResponse], error) {
+func (c *shoppingListServiceClient) UpdatePlan(ctx context.Context, req *connect.Request[genpb.UpdatePlanRequest]) (*connect.Response[genpb.UpdatePlanResponse], error) {
 	return c.updatePlan.CallUnary(ctx, req)
 }
 
 // GetMeals calls ShoppingListService.GetMeals.
-func (c *shoppingListServiceClient) GetMeals(ctx context.Context, req *connect.Request[gen.GetMealsRequest]) (*connect.Response[gen.GetMealsResponse], error) {
+func (c *shoppingListServiceClient) GetMeals(ctx context.Context, req *connect.Request[genpb.GetMealsRequest]) (*connect.Response[genpb.GetMealsResponse], error) {
 	return c.getMeals.CallUnary(ctx, req)
 }
 
 // CreateMeal calls ShoppingListService.CreateMeal.
-func (c *shoppingListServiceClient) CreateMeal(ctx context.Context, req *connect.Request[gen.CreateMealRequest]) (*connect.Response[gen.CreateMealResponse], error) {
+func (c *shoppingListServiceClient) CreateMeal(ctx context.Context, req *connect.Request[genpb.CreateMealRequest]) (*connect.Response[genpb.CreateMealResponse], error) {
 	return c.createMeal.CallUnary(ctx, req)
 }
 
 // UpdateMeal calls ShoppingListService.UpdateMeal.
-func (c *shoppingListServiceClient) UpdateMeal(ctx context.Context, req *connect.Request[gen.UpdateMealRequest]) (*connect.Response[gen.UpdateMealResponse], error) {
+func (c *shoppingListServiceClient) UpdateMeal(ctx context.Context, req *connect.Request[genpb.UpdateMealRequest]) (*connect.Response[genpb.UpdateMealResponse], error) {
 	return c.updateMeal.CallUnary(ctx, req)
 }
 
 // DeleteMeal calls ShoppingListService.DeleteMeal.
-func (c *shoppingListServiceClient) DeleteMeal(ctx context.Context, req *connect.Request[gen.DeleteMealRequest]) (*connect.Response[gen.DeleteMealResponse], error) {
+func (c *shoppingListServiceClient) DeleteMeal(ctx context.Context, req *connect.Request[genpb.DeleteMealRequest]) (*connect.Response[genpb.DeleteMealResponse], error) {
 	return c.deleteMeal.CallUnary(ctx, req)
 }
 
 // GetIngredients calls ShoppingListService.GetIngredients.
-func (c *shoppingListServiceClient) GetIngredients(ctx context.Context, req *connect.Request[gen.GetIngredientsRequest]) (*connect.Response[gen.GetIngredientsResponse], error) {
+func (c *shoppingListServiceClient) GetIngredients(ctx context.Context, req *connect.Request[genpb.GetIngredientsRequest]) (*connect.Response[genpb.GetIngredientsResponse], error) {
 	return c.getIngredients.CallUnary(ctx, req)
 }
 
 // CreateIngredient calls ShoppingListService.CreateIngredient.
-func (c *shoppingListServiceClient) CreateIngredient(ctx context.Context, req *connect.Request[gen.CreateIngredientRequest]) (*connect.Response[gen.CreateIngredientResponse], error) {
+func (c *shoppingListServiceClient) CreateIngredient(ctx context.Context, req *connect.Request[genpb.CreateIngredientRequest]) (*connect.Response[genpb.CreateIngredientResponse], error) {
 	return c.createIngredient.CallUnary(ctx, req)
 }
 
 // UpdateIngredient calls ShoppingListService.UpdateIngredient.
-func (c *shoppingListServiceClient) UpdateIngredient(ctx context.Context, req *connect.Request[gen.UpdateIngredientRequest]) (*connect.Response[gen.UpdateIngredientResponse], error) {
+func (c *shoppingListServiceClient) UpdateIngredient(ctx context.Context, req *connect.Request[genpb.UpdateIngredientRequest]) (*connect.Response[genpb.UpdateIngredientResponse], error) {
 	return c.updateIngredient.CallUnary(ctx, req)
 }
 
 // DeleteIngredient calls ShoppingListService.DeleteIngredient.
-func (c *shoppingListServiceClient) DeleteIngredient(ctx context.Context, req *connect.Request[gen.DeleteIngredientRequest]) (*connect.Response[gen.DeleteIngredientResponse], error) {
+func (c *shoppingListServiceClient) DeleteIngredient(ctx context.Context, req *connect.Request[genpb.DeleteIngredientRequest]) (*connect.Response[genpb.DeleteIngredientResponse], error) {
 	return c.deleteIngredient.CallUnary(ctx, req)
 }
 
 // ShoppingListServiceHandler is an implementation of the ShoppingListService service.
 type ShoppingListServiceHandler interface {
 	// plan
-	GetPlan(context.Context, *connect.Request[gen.GetPlanRequest]) (*connect.Response[gen.GetPlanResponse], error)
-	UpdatePlan(context.Context, *connect.Request[gen.UpdatePlanRequest]) (*connect.Response[gen.UpdatePlanResponse], error)
+	GetPlan(context.Context, *connect.Request[genpb.GetPlanRequest]) (*connect.Response[genpb.GetPlanResponse], error)
+	UpdatePlan(context.Context, *connect.Request[genpb.UpdatePlanRequest]) (*connect.Response[genpb.UpdatePlanResponse], error)
 	// meals
-	GetMeals(context.Context, *connect.Request[gen.GetMealsRequest]) (*connect.Response[gen.GetMealsResponse], error)
-	CreateMeal(context.Context, *connect.Request[gen.CreateMealRequest]) (*connect.Response[gen.CreateMealResponse], error)
-	UpdateMeal(context.Context, *connect.Request[gen.UpdateMealRequest]) (*connect.Response[gen.UpdateMealResponse], error)
-	DeleteMeal(context.Context, *connect.Request[gen.DeleteMealRequest]) (*connect.Response[gen.DeleteMealResponse], error)
-	GetIngredients(context.Context, *connect.Request[gen.GetIngredientsRequest]) (*connect.Response[gen.GetIngredientsResponse], error)
-	CreateIngredient(context.Context, *connect.Request[gen.CreateIngredientRequest]) (*connect.Response[gen.CreateIngredientResponse], error)
-	UpdateIngredient(context.Context, *connect.Request[gen.UpdateIngredientRequest]) (*connect.Response[gen.UpdateIngredientResponse], error)
-	DeleteIngredient(context.Context, *connect.Request[gen.DeleteIngredientRequest]) (*connect.Response[gen.DeleteIngredientResponse], error)
+	GetMeals(context.Context, *connect.Request[genpb.GetMealsRequest]) (*connect.Response[genpb.GetMealsResponse], error)
+	CreateMeal(context.Context, *connect.Request[genpb.CreateMealRequest]) (*connect.Response[genpb.CreateMealResponse], error)
+	UpdateMeal(context.Context, *connect.Request[genpb.UpdateMealRequest]) (*connect.Response[genpb.UpdateMealResponse], error)
+	DeleteMeal(context.Context, *connect.Request[genpb.DeleteMealRequest]) (*connect.Response[genpb.DeleteMealResponse], error)
+	GetIngredients(context.Context, *connect.Request[genpb.GetIngredientsRequest]) (*connect.Response[genpb.GetIngredientsResponse], error)
+	CreateIngredient(context.Context, *connect.Request[genpb.CreateIngredientRequest]) (*connect.Response[genpb.CreateIngredientResponse], error)
+	UpdateIngredient(context.Context, *connect.Request[genpb.UpdateIngredientRequest]) (*connect.Response[genpb.UpdateIngredientResponse], error)
+	DeleteIngredient(context.Context, *connect.Request[genpb.DeleteIngredientRequest]) (*connect.Response[genpb.DeleteIngredientResponse], error)
 }
 
 // NewShoppingListServiceHandler builds an HTTP handler from the service implementation. It returns
@@ -241,7 +241,7 @@ type ShoppingListServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewShoppingListServiceHandler(svc ShoppingListServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
-	shoppingListServiceMethods := gen.File_shopping_list_service_proto.Services().ByName("ShoppingListService").Methods()
+	shoppingListServiceMethods := genpb.File_shopping_list_service_proto.Services().ByName("ShoppingListService").Methods()
 	shoppingListServiceGetPlanHandler := connect.NewUnaryHandler(
 		ShoppingListServiceGetPlanProcedure,
 		svc.GetPlan,
@@ -333,42 +333,42 @@ func NewShoppingListServiceHandler(svc ShoppingListServiceHandler, opts ...conne
 // UnimplementedShoppingListServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedShoppingListServiceHandler struct{}
 
-func (UnimplementedShoppingListServiceHandler) GetPlan(context.Context, *connect.Request[gen.GetPlanRequest]) (*connect.Response[gen.GetPlanResponse], error) {
+func (UnimplementedShoppingListServiceHandler) GetPlan(context.Context, *connect.Request[genpb.GetPlanRequest]) (*connect.Response[genpb.GetPlanResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("ShoppingListService.GetPlan is not implemented"))
 }
 
-func (UnimplementedShoppingListServiceHandler) UpdatePlan(context.Context, *connect.Request[gen.UpdatePlanRequest]) (*connect.Response[gen.UpdatePlanResponse], error) {
+func (UnimplementedShoppingListServiceHandler) UpdatePlan(context.Context, *connect.Request[genpb.UpdatePlanRequest]) (*connect.Response[genpb.UpdatePlanResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("ShoppingListService.UpdatePlan is not implemented"))
 }
 
-func (UnimplementedShoppingListServiceHandler) GetMeals(context.Context, *connect.Request[gen.GetMealsRequest]) (*connect.Response[gen.GetMealsResponse], error) {
+func (UnimplementedShoppingListServiceHandler) GetMeals(context.Context, *connect.Request[genpb.GetMealsRequest]) (*connect.Response[genpb.GetMealsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("ShoppingListService.GetMeals is not implemented"))
 }
 
-func (UnimplementedShoppingListServiceHandler) CreateMeal(context.Context, *connect.Request[gen.CreateMealRequest]) (*connect.Response[gen.CreateMealResponse], error) {
+func (UnimplementedShoppingListServiceHandler) CreateMeal(context.Context, *connect.Request[genpb.CreateMealRequest]) (*connect.Response[genpb.CreateMealResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("ShoppingListService.CreateMeal is not implemented"))
 }
 
-func (UnimplementedShoppingListServiceHandler) UpdateMeal(context.Context, *connect.Request[gen.UpdateMealRequest]) (*connect.Response[gen.UpdateMealResponse], error) {
+func (UnimplementedShoppingListServiceHandler) UpdateMeal(context.Context, *connect.Request[genpb.UpdateMealRequest]) (*connect.Response[genpb.UpdateMealResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("ShoppingListService.UpdateMeal is not implemented"))
 }
 
-func (UnimplementedShoppingListServiceHandler) DeleteMeal(context.Context, *connect.Request[gen.DeleteMealRequest]) (*connect.Response[gen.DeleteMealResponse], error) {
+func (UnimplementedShoppingListServiceHandler) DeleteMeal(context.Context, *connect.Request[genpb.DeleteMealRequest]) (*connect.Response[genpb.DeleteMealResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("ShoppingListService.DeleteMeal is not implemented"))
 }
 
-func (UnimplementedShoppingListServiceHandler) GetIngredients(context.Context, *connect.Request[gen.GetIngredientsRequest]) (*connect.Response[gen.GetIngredientsResponse], error) {
+func (UnimplementedShoppingListServiceHandler) GetIngredients(context.Context, *connect.Request[genpb.GetIngredientsRequest]) (*connect.Response[genpb.GetIngredientsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("ShoppingListService.GetIngredients is not implemented"))
 }
 
-func (UnimplementedShoppingListServiceHandler) CreateIngredient(context.Context, *connect.Request[gen.CreateIngredientRequest]) (*connect.Response[gen.CreateIngredientResponse], error) {
+func (UnimplementedShoppingListServiceHandler) CreateIngredient(context.Context, *connect.Request[genpb.CreateIngredientRequest]) (*connect.Response[genpb.CreateIngredientResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("ShoppingListService.CreateIngredient is not implemented"))
 }
 
-func (UnimplementedShoppingListServiceHandler) UpdateIngredient(context.Context, *connect.Request[gen.UpdateIngredientRequest]) (*connect.Response[gen.UpdateIngredientResponse], error) {
+func (UnimplementedShoppingListServiceHandler) UpdateIngredient(context.Context, *connect.Request[genpb.UpdateIngredientRequest]) (*connect.Response[genpb.UpdateIngredientResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("ShoppingListService.UpdateIngredient is not implemented"))
 }
 
-func (UnimplementedShoppingListServiceHandler) DeleteIngredient(context.Context, *connect.Request[gen.DeleteIngredientRequest]) (*connect.Response[gen.DeleteIngredientResponse], error) {
+func (UnimplementedShoppingListServiceHandler) DeleteIngredient(context.Context, *connect.Request[genpb.DeleteIngredientRequest]) (*connect.Response[genpb.DeleteIngredientResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("ShoppingListService.DeleteIngredient is not implemented"))
 }

--- a/backend/genpb/ingredient.pb.go
+++ b/backend/genpb/ingredient.pb.go
@@ -4,7 +4,7 @@
 // 	protoc        (unknown)
 // source: ingredient.proto
 
-package gen
+package genpb
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -81,7 +81,7 @@ const file_ingredient_proto_rawDesc = "" +
 	"\n" +
 	"Ingredient\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04nameBEB\x0fIngredientProtoP\x01Z0github.com/chrisjpalmer/shoppinglist/backend/genb\x06proto3"
+	"\x04name\x18\x02 \x01(\tR\x04nameBGB\x0fIngredientProtoP\x01Z2github.com/chrisjpalmer/shoppinglist/backend/genpbb\x06proto3"
 
 var (
 	file_ingredient_proto_rawDescOnce sync.Once

--- a/backend/genpb/meal.pb.go
+++ b/backend/genpb/meal.pb.go
@@ -4,7 +4,7 @@
 // 	protoc        (unknown)
 // source: meal.proto
 
-package gen
+package genpb
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -155,7 +155,7 @@ const file_meal_proto_rawDesc = "" +
 	"recipe_url\x18\x04 \x01(\tR\trecipeUrl\"L\n" +
 	"\rIngredientRef\x12#\n" +
 	"\ringredient_id\x18\x01 \x01(\x03R\fingredientId\x12\x16\n" +
-	"\x06number\x18\x02 \x01(\x05R\x06numberB?B\tMealProtoP\x01Z0github.com/chrisjpalmer/shoppinglist/backend/genb\x06proto3"
+	"\x06number\x18\x02 \x01(\x05R\x06numberBAB\tMealProtoP\x01Z2github.com/chrisjpalmer/shoppinglist/backend/genpbb\x06proto3"
 
 var (
 	file_meal_proto_rawDescOnce sync.Once

--- a/backend/genpb/plan.pb.go
+++ b/backend/genpb/plan.pb.go
@@ -4,7 +4,7 @@
 // 	protoc        (unknown)
 // source: plan.proto
 
-package gen
+package genpb
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -273,7 +273,7 @@ const file_plan_proto_rawDesc = "" +
 	"\bCategory\x12\x12\n" +
 	"\x0eCATEGORY_LUNCH\x10\x00\x12\x13\n" +
 	"\x0fCATEGORY_DINNER\x10\x01\x12\x12\n" +
-	"\x0eCATEGORY_SNACK\x10\x02B?B\tPlanProtoP\x01Z0github.com/chrisjpalmer/shoppinglist/backend/genb\x06proto3"
+	"\x0eCATEGORY_SNACK\x10\x02BAB\tPlanProtoP\x01Z2github.com/chrisjpalmer/shoppinglist/backend/genpbb\x06proto3"
 
 var (
 	file_plan_proto_rawDescOnce sync.Once

--- a/backend/genpb/shopping_list_service.pb.go
+++ b/backend/genpb/shopping_list_service.pb.go
@@ -4,7 +4,7 @@
 // 	protoc        (unknown)
 // source: shopping_list_service.proto
 
-package gen
+package genpb
 
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -903,7 +903,7 @@ const file_shopping_list_service_proto_rawDesc = "" +
 	"\x0eGetIngredients\x12\x16.GetIngredientsRequest\x1a\x17.GetIngredientsResponse\x12G\n" +
 	"\x10CreateIngredient\x12\x18.CreateIngredientRequest\x1a\x19.CreateIngredientResponse\x12G\n" +
 	"\x10UpdateIngredient\x12\x18.UpdateIngredientRequest\x1a\x19.UpdateIngredientResponse\x12G\n" +
-	"\x10DeleteIngredient\x12\x18.DeleteIngredientRequest\x1a\x19.DeleteIngredientResponseBNB\x18ShoppingListServiceProtoP\x01Z0github.com/chrisjpalmer/shoppinglist/backend/genb\x06proto3"
+	"\x10DeleteIngredient\x12\x18.DeleteIngredientRequest\x1a\x19.DeleteIngredientResponseBPB\x18ShoppingListServiceProtoP\x01Z2github.com/chrisjpalmer/shoppinglist/backend/genpbb\x06proto3"
 
 var (
 	file_shopping_list_service_proto_rawDescOnce sync.Once

--- a/backend/shopping/want.go
+++ b/backend/shopping/want.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/a-h/templ"
-	"github.com/chrisjpalmer/shoppinglist/backend/gen"
+	"github.com/chrisjpalmer/shoppinglist/backend/genpb"
 	"github.com/chrisjpalmer/shoppinglist/backend/gensql"
 	"github.com/chrisjpalmer/shoppinglist/backend/shopping/page"
 	"github.com/chrisjpalmer/shoppinglist/backend/shopping/render"
@@ -179,7 +179,7 @@ func (s *Server) ingredients(ctx context.Context) (map[int64]int32, []gensql.Ing
 	return ingredientCounts, ingg, nil
 }
 
-func (s *Server) plan(ctx context.Context) (*gen.Plan, error) {
+func (s *Server) plan(ctx context.Context) (*genpb.Plan, error) {
 	p, err := s.sql.GetPlan(ctx)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -189,7 +189,7 @@ func (s *Server) plan(ctx context.Context) (*gen.Plan, error) {
 		return nil, err
 	}
 
-	var plan gen.Plan
+	var plan genpb.Plan
 	err = unmarshalJSON(p.PlanData, &plan)
 	if err != nil {
 		return nil, err
@@ -198,22 +198,22 @@ func (s *Server) plan(ctx context.Context) (*gen.Plan, error) {
 	return &plan, nil
 }
 
-func emptyPlan() *gen.Plan {
-	var days []*gen.Day
+func emptyPlan() *genpb.Plan {
+	var days []*genpb.Day
 	for range 7 {
-		days = append(days, &gen.Day{
-			CategoryMeals: []*gen.CategoryMeal{
+		days = append(days, &genpb.Day{
+			CategoryMeals: []*genpb.CategoryMeal{
 				// 0 = lunch, 1 = dinner, 2 = snack
-				{Category: gen.Category_CATEGORY_LUNCH}, {Category: gen.Category_CATEGORY_DINNER}, {Category: gen.Category_CATEGORY_SNACK},
+				{Category: genpb.Category_CATEGORY_LUNCH}, {Category: genpb.Category_CATEGORY_DINNER}, {Category: genpb.Category_CATEGORY_SNACK},
 			},
 		})
 	}
-	return &gen.Plan{
+	return &genpb.Plan{
 		Days: days,
 	}
 }
 
-func selectedMealIds(p *gen.Plan) []int64 {
+func selectedMealIds(p *genpb.Plan) []int64 {
 	var meals []int64
 	for _, d := range p.Days {
 		for _, cm := range d.CategoryMeals {
@@ -227,17 +227,17 @@ func selectedMealIds(p *gen.Plan) []int64 {
 	return meals
 }
 
-func mealsMap(meals []gensql.GetMealsRow) (map[int64]*gen.Meal, error) {
-	mealsmap := make(map[int64]*gen.Meal)
+func mealsMap(meals []gensql.GetMealsRow) (map[int64]*genpb.Meal, error) {
+	mealsmap := make(map[int64]*genpb.Meal)
 	for _, m := range meals {
-		var igrefs []*gen.IngredientRef
+		var igrefs []*genpb.IngredientRef
 
 		err := unmarshalJSON(m.Ingredients, &igrefs)
 		if err != nil {
 			return nil, err
 		}
 
-		mealsmap[m.ID] = &gen.Meal{
+		mealsmap[m.ID] = &genpb.Meal{
 			Name:           m.Name,
 			Id:             m.ID,
 			IngredientRefs: igrefs,


### PR DESCRIPTION
Rename generated protobuf code from `gen` to `genpb` to align with the approach taken to generated sqlc code as well as provide better clarity.