### PR TITLE
⚡️ Introduce npm volume caching

### DIFF
--- a/.dagger/internal/dagger/dagger.gen.go
+++ b/.dagger/internal/dagger/dagger.gen.go
@@ -7321,7 +7321,7 @@ func (r *Frontend) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *Frontend) Publish(ctx context.Context, tag string, registryPassword *Secret) error { // frontend (../../../frontend/.dagger/main.go:78:1)
+func (r *Frontend) Publish(ctx context.Context, tag string, registryPassword *Secret) error { // frontend (../../../frontend/.dagger/main.go:80:1)
 	assertNotNil("registryPassword", registryPassword)
 	if r.publish != nil {
 		return nil

--- a/frontend/.dagger/main.go
+++ b/frontend/.dagger/main.go
@@ -56,6 +56,7 @@ func (m *Frontend) build(
 
 	build := dag.Container().
 		From(nodeVersion).
+		WithMountedCache("/root/.npm", dag.CacheVolume("npm-build-cache")).
 		WithWorkdir("/app").
 		WithDirectory(".", m.Src).
 		WithExec([]string{"npm", "install"}).
@@ -67,9 +68,10 @@ func (m *Frontend) build(
 		Platform: platform,
 	}).
 		From(nodeVersion).
+		WithMountedCache("/root/.npm", dag.CacheVolume("npm-build-cache")).
 		WithWorkdir("/app").
 		WithFiles(".", []*dagger.File{m.Src.File("package.json"), m.Src.File("package-lock.json")}).
-		WithExec([]string{"npm", "install"}).
+		WithExec([]string{"npm", "install", "--omit=dev"}).
 		WithDirectory("build", build).
 		WithEntrypoint([]string{"node", "build"}).Sync(ctx)
 }


### PR DESCRIPTION
Introduce npm volume caching to improve build performance by persisting the npm cache across runs via a mounted cache volume.