### PR TITLE
♻️ Refactor build container to its own function

### DIFF
--- a/.dagger/internal/dagger/dagger.gen.go
+++ b/.dagger/internal/dagger/dagger.gen.go
@@ -7264,7 +7264,7 @@ func (r *Frontend) WithGraphQLQuery(q *querybuilder.Selection) *Frontend {
 	}
 }
 
-func (r *Frontend) BuildCheck() *Container { // frontend (../../../frontend/.dagger/main.go:41:1)
+func (r *Frontend) BuildCheck() *Container { // frontend (../../../frontend/.dagger/main.go:44:1)
 	q := r.query.Select("buildCheck")
 
 	return &Container{
@@ -7321,7 +7321,7 @@ func (r *Frontend) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *Frontend) Publish(ctx context.Context, tag string, registryPassword *Secret) error { // frontend (../../../frontend/.dagger/main.go:80:1)
+func (r *Frontend) Publish(ctx context.Context, tag string, registryPassword *Secret) error { // frontend (../../../frontend/.dagger/main.go:88:1)
 	assertNotNil("registryPassword", registryPassword)
 	if r.publish != nil {
 		return nil
@@ -7333,7 +7333,7 @@ func (r *Frontend) Publish(ctx context.Context, tag string, registryPassword *Se
 	return q.Execute(ctx)
 }
 
-func (r *Frontend) Src() *Directory { // frontend (../../../frontend/.dagger/main.go:29:2)
+func (r *Frontend) Src() *Directory { // frontend (../../../frontend/.dagger/main.go:31:2)
 	q := r.query.Select("src")
 
 	return &Directory{
@@ -13176,10 +13176,10 @@ func (r *Client) File(name string, contents string, opts ...FileOpts) *File {
 
 // FrontendOpts contains options for Client.Frontend
 type FrontendOpts struct {
-	Ws *Workspace // frontend (../../../frontend/.dagger/main.go:33:2)
+	Ws *Workspace // frontend (../../../frontend/.dagger/main.go:35:2)
 }
 
-func (r *Client) Frontend(opts ...FrontendOpts) *Frontend { // frontend (../../../frontend/.dagger/main.go:32:1)
+func (r *Client) Frontend(opts ...FrontendOpts) *Frontend { // frontend (../../../frontend/.dagger/main.go:34:1)
 	q := r.query.Select("frontend")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `ws` optional argument

--- a/frontend/.dagger/dagger.gen.go
+++ b/frontend/.dagger/dagger.gen.go
@@ -58,20 +58,24 @@ func convertSlice[I any, O any](in []I, f func(I) O) []O {
 
 func (r Frontend) MarshalJSON() ([]byte, error) {
 	var concrete struct {
-		Src *dagger.Directory
+		RootSrc *dagger.Directory
+		Src     *dagger.Directory
 	}
+	concrete.RootSrc = r.RootSrc
 	concrete.Src = r.Src
 	return json.Marshal(&concrete)
 }
 
 func (r *Frontend) UnmarshalJSON(bs []byte) error {
 	var concrete struct {
-		Src *dagger.Directory
+		RootSrc *dagger.Directory
+		Src     *dagger.Directory
 	}
 	err := json.Unmarshal(bs, &concrete)
 	if err != nil {
 		return err
 	}
+	r.RootSrc = concrete.RootSrc
 	r.Src = concrete.Src
 	return nil
 }

--- a/frontend/.dagger/main.go
+++ b/frontend/.dagger/main.go
@@ -26,14 +26,17 @@ import (
 const nodeVersion = "node:22.18.0"
 
 type Frontend struct {
-	Src *dagger.Directory
+	// +private
+	RootSrc *dagger.Directory
+	Src     *dagger.Directory
 }
 
 func New(
 	ws *dagger.Workspace,
 ) *Frontend {
 	return &Frontend{
-		Src: ws.Directory("/frontend", dagger.WorkspaceDirectoryOpts{Gitignore: true}),
+		RootSrc: ws.Directory("/", dagger.WorkspaceDirectoryOpts{Gitignore: true}),
+		Src:     ws.Directory("/frontend", dagger.WorkspaceDirectoryOpts{Gitignore: true}),
 	}
 }
 
@@ -54,11 +57,7 @@ func (m *Frontend) build(
 	ctx, span := Tracer().Start(ctx, "build: "+string(platform))
 	defer telemetry.EndWithCause(span, &rerr)
 
-	build := dag.Container().
-		From(nodeVersion).
-		WithMountedCache("/root/.npm", dag.CacheVolume("npm-build-cache")).
-		WithWorkdir("/app").
-		WithDirectory(".", m.Src).
+	build := m.buildCtr().
 		WithExec([]string{"npm", "install"}).
 		WithEnvVariable("PUBLIC_BACKEND_PORT", "30001").
 		WithExec([]string{"npm", "run", "build"}).
@@ -74,6 +73,15 @@ func (m *Frontend) build(
 		WithExec([]string{"npm", "install", "--omit=dev"}).
 		WithDirectory("build", build).
 		WithEntrypoint([]string{"node", "build"}).Sync(ctx)
+}
+
+func (m *Frontend) buildCtr() *dagger.Container {
+	return dag.Container().
+		From(nodeVersion).
+		WithMountedCache("/root/.npm", dag.CacheVolume("npm-build-cache")).
+		WithWorkdir("/app").
+		WithDirectory(".", m.RootSrc).
+		WithWorkdir("frontend")
 }
 
 // +cache="never"


### PR DESCRIPTION
Refactor the build container setup into a dedicated buildCtr() function to make it easier to reuse the build container in future tasks.