### PR TITLE
✨ Introduce dagger services for simplified testing

### DIFF
--- a/.dagger/internal/dagger/backend.gen.go
+++ b/.dagger/internal/dagger/backend.gen.go
@@ -33,6 +33,26 @@ func (r *Backend) WithGraphQLQuery(q *querybuilder.Selection) *Backend {
 	}
 }
 
+// BackendBackendServiceOpts contains options for Backend.BackendService
+type BackendBackendServiceOpts struct {
+	Ws *Workspace // backend (../../../backend/.dagger/service.go:21:55)
+}
+
+// BackendService - runs the backend service inside a container
+func (r *Backend) BackendService(opts ...BackendBackendServiceOpts) *Service { // backend (../../../backend/.dagger/service.go:21:1)
+	q := r.query.Select("backendService")
+	for i := len(opts) - 1; i >= 0; i-- {
+		// `ws` optional argument
+		if !querybuilder.IsZeroValue(opts[i].Ws) {
+			q = q.Arg("ws", opts[i].Ws)
+		}
+	}
+
+	return &Service{
+		query: q,
+	}
+}
+
 func (r *Backend) BuildCheck() *Container { // backend (../../../backend/.dagger/build.go:14:1)
 	q := r.query.Select("buildCheck")
 

--- a/.dagger/internal/dagger/frontend.gen.go
+++ b/.dagger/internal/dagger/frontend.gen.go
@@ -10,10 +10,10 @@ import (
 )
 
 // The `FrontendID` scalar type represents an identifier for an object of type Frontend.
-type FrontendID string // frontend (../../../frontend/.dagger/main.go:28:6)
+type FrontendID string // frontend (../../../frontend/.dagger/main.go:35:6)
 
 // Retrieve the binding value, as type Frontend
-func (r *Binding) AsFrontend() *Frontend { // frontend (../../../frontend/.dagger/main.go:28:6)
+func (r *Binding) AsFrontend() *Frontend { // frontend (../../../frontend/.dagger/main.go:35:6)
 	q := r.query.Select("asFrontend")
 
 	return &Frontend{
@@ -22,7 +22,7 @@ func (r *Binding) AsFrontend() *Frontend { // frontend (../../../frontend/.dagge
 }
 
 // Create or update a binding of type Frontend in the environment
-func (r *Env) WithFrontendInput(name string, value *Frontend, description string) *Env { // frontend (../../../frontend/.dagger/main.go:28:6)
+func (r *Env) WithFrontendInput(name string, value *Frontend, description string) *Env { // frontend (../../../frontend/.dagger/main.go:35:6)
 	assertNotNil("value", value)
 	q := r.query.Select("withFrontendInput")
 	q = q.Arg("name", name)
@@ -35,7 +35,7 @@ func (r *Env) WithFrontendInput(name string, value *Frontend, description string
 }
 
 // Declare a desired Frontend output to be assigned in the environment
-func (r *Env) WithFrontendOutput(name string, description string) *Env { // frontend (../../../frontend/.dagger/main.go:28:6)
+func (r *Env) WithFrontendOutput(name string, description string) *Env { // frontend (../../../frontend/.dagger/main.go:35:6)
 	q := r.query.Select("withFrontendOutput")
 	q = q.Arg("name", name)
 	q = q.Arg("description", description)
@@ -45,7 +45,7 @@ func (r *Env) WithFrontendOutput(name string, description string) *Env { // fron
 	}
 }
 
-type Frontend struct { // frontend (../../../frontend/.dagger/main.go:28:6)
+type Frontend struct { // frontend (../../../frontend/.dagger/main.go:35:6)
 	query *querybuilder.Selection
 
 	checkProtos *Void
@@ -59,7 +59,7 @@ func (r *Frontend) WithGraphQLQuery(q *querybuilder.Selection) *Frontend {
 	}
 }
 
-func (r *Frontend) BuildCheck() *Container { // frontend (../../../frontend/.dagger/main.go:44:1)
+func (r *Frontend) BuildCheck() *Container { // frontend (../../../frontend/.dagger/main.go:51:1)
 	q := r.query.Select("buildCheck")
 
 	return &Container{
@@ -75,6 +75,15 @@ func (r *Frontend) CheckProtos(ctx context.Context) error { // frontend (../../.
 	q := r.query.Select("checkProtos")
 
 	return q.Execute(ctx)
+}
+
+// FrontendService - runs the frontend service inside a container
+func (r *Frontend) FrontendService() *Service { // frontend (../../../frontend/.dagger/service.go:21:1)
+	q := r.query.Select("frontendService")
+
+	return &Service{
+		query: q,
+	}
 }
 
 // GenerateProtos - generate protobuf codegen from .proto files
@@ -135,7 +144,7 @@ func (r *Frontend) UnmarshalJSON(bs []byte) error {
 	return nil
 }
 
-func (r *Frontend) Publish(ctx context.Context, tag string, registryPassword *Secret) error { // frontend (../../../frontend/.dagger/main.go:88:1)
+func (r *Frontend) Publish(ctx context.Context, tag string, registryPassword *Secret) error { // frontend (../../../frontend/.dagger/main.go:96:1)
 	assertNotNil("registryPassword", registryPassword)
 	if r.publish != nil {
 		return nil
@@ -147,7 +156,7 @@ func (r *Frontend) Publish(ctx context.Context, tag string, registryPassword *Se
 	return q.Execute(ctx)
 }
 
-func (r *Frontend) Src() *Directory { // frontend (../../../frontend/.dagger/main.go:31:2)
+func (r *Frontend) Src() *Directory { // frontend (../../../frontend/.dagger/main.go:38:2)
 	q := r.query.Select("src")
 
 	return &Directory{
@@ -157,7 +166,7 @@ func (r *Frontend) Src() *Directory { // frontend (../../../frontend/.dagger/mai
 
 // FrontendOpts contains options for Query.Frontend
 type FrontendOpts struct {
-	Ws *Workspace // frontend (../../../frontend/.dagger/main.go:35:2)
+	Ws *Workspace // frontend (../../../frontend/.dagger/main.go:42:2)
 }
 
 // A generated module for Frontend functions
@@ -173,7 +182,7 @@ type FrontendOpts struct {
 // The first line in this comment block is a short description line and the
 // rest is a long description with more detail on the module's purpose or usage,
 // if appropriate. All modules should have a short description.
-func (r *Query) Frontend(opts ...FrontendOpts) *Frontend { // frontend (../../../frontend/.dagger/main.go:34:1)
+func (r *Query) Frontend(opts ...FrontendOpts) *Frontend { // frontend (../../../frontend/.dagger/main.go:41:1)
 	q := r.query.Select("frontend")
 	for i := len(opts) - 1; i >= 0; i-- {
 		// `ws` optional argument
@@ -188,7 +197,7 @@ func (r *Query) Frontend(opts ...FrontendOpts) *Frontend { // frontend (../../..
 }
 
 // Load a Frontend from its ID.
-func (r *Query) LoadFrontendFromID(id FrontendID) *Frontend { // frontend (../../../frontend/.dagger/main.go:28:6)
+func (r *Query) LoadFrontendFromID(id FrontendID) *Frontend { // frontend (../../../frontend/.dagger/main.go:35:6)
 	q := r.query.Select("loadFrontendFromID")
 	q = q.Arg("id", id)
 

--- a/backend/.dagger/dagger.gen.go
+++ b/backend/.dagger/dagger.gen.go
@@ -199,6 +199,20 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 	switch parentName {
 	case "Backend":
 		switch fnName {
+		case "BackendService":
+			var parent Backend
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			var ws *dagger.Workspace
+			if inputArgs["ws"] != nil {
+				err = json.Unmarshal([]byte(inputArgs["ws"]), &ws)
+				if err != nil {
+					panic(fmt.Errorf("%s: %w", "failed to unmarshal input arg ws", err))
+				}
+			}
+			return (*Backend).BackendService(&parent, ctx, ws)
 		case "BuildCheck":
 			var parent Backend
 			err = json.Unmarshal(parentJSON, &parent)

--- a/backend/.dagger/service.go
+++ b/backend/.dagger/service.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"dagger/backend/internal/dagger"
+	"fmt"
+)
+
+const (
+	// localBackendApiPort - the default port that the backend api server
+	// is served from.
+	localBackendApiPort = 8080
+
+	// localBackendShoppingSitePort - the default port that the shopping site
+	// is served from.
+	localBackendShoppingSitePort = 8081
+)
+
+// BackendService - runs the backend service inside a container
+// +up
+func (m *Backend) BackendService(ctx context.Context, ws *dagger.Workspace) (*dagger.Service, error) {
+	plt, err := dag.DefaultPlatform(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ctr, err := m.build(ctx, plt)
+	if err != nil {
+		return nil, fmt.Errorf("error building backend: %w", err)
+	}
+
+	return ctr.
+		WithMountedDirectory("local", ws.Directory("/backend/local")).
+		WithExposedPort(localBackendApiPort).
+		WithExposedPort(localBackendShoppingSitePort).
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true}), nil
+}

--- a/frontend/.dagger/dagger.gen.go
+++ b/frontend/.dagger/dagger.gen.go
@@ -213,6 +213,13 @@ func invoke(ctx context.Context, parentJSON []byte, parentName string, fnName st
 				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
 			}
 			return nil, (*Frontend).CheckProtos(&parent, ctx)
+		case "FrontendService":
+			var parent Frontend
+			err = json.Unmarshal(parentJSON, &parent)
+			if err != nil {
+				panic(fmt.Errorf("%s: %w", "failed to unmarshal parent object", err))
+			}
+			return (*Frontend).FrontendService(&parent, ctx)
 		case "GenerateProtos":
 			var parent Frontend
 			err = json.Unmarshal(parentJSON, &parent)

--- a/frontend/.dagger/main.go
+++ b/frontend/.dagger/main.go
@@ -18,12 +18,19 @@ import (
 	"context"
 	"dagger/frontend/internal/dagger"
 	"fmt"
+	"strconv"
 
 	telemetry "github.com/dagger/otel-go"
 	"golang.org/x/sync/errgroup"
 )
 
-const nodeVersion = "node:22.18.0"
+const (
+	nodeVersion = "node:22.18.0"
+
+	// helmBackendPort - the port of the api server from the backend helm chart.
+	// This value must be synced with the helm chart
+	helmBackendPort = 30001
+)
 
 type Frontend struct {
 	// +private
@@ -47,19 +54,20 @@ func (m *Frontend) BuildCheck(ctx context.Context) (*dagger.Container, error) {
 		return nil, err
 	}
 
-	return m.build(ctx, plt)
+	return m.build(ctx, plt, helmBackendPort)
 }
 
 func (m *Frontend) build(
 	ctx context.Context,
 	platform dagger.Platform,
+	backendPort int,
 ) (_ *dagger.Container, rerr error) {
 	ctx, span := Tracer().Start(ctx, "build: "+string(platform))
 	defer telemetry.EndWithCause(span, &rerr)
 
 	build := m.buildCtr().
 		WithExec([]string{"npm", "install"}).
-		WithEnvVariable("PUBLIC_BACKEND_PORT", "30001").
+		WithEnvVariable("PUBLIC_BACKEND_PORT", strconv.Itoa(backendPort)).
 		WithExec([]string{"npm", "run", "build"}).
 		Directory("build")
 
@@ -98,7 +106,7 @@ func (m *Frontend) Publish(
 
 	for i, plt := range plats {
 		errg.Go(func() error {
-			build, err := m.build(gctx, plt)
+			build, err := m.build(gctx, plt, helmBackendPort)
 			if err != nil {
 				return err
 			}

--- a/frontend/.dagger/service.go
+++ b/frontend/.dagger/service.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"dagger/frontend/internal/dagger"
+	"fmt"
+)
+
+const (
+	// localBackendPort - the port of the api server when the backend is served locally.
+	// This value must be synced with the default port in the backend code
+	localBackendPort = 8080
+
+	// localFrontendPort - the port of the frontend website.
+	// This is the default for the svelte setup being used.
+	localFrontendPort = 3000
+)
+
+// FrontendService - runs the frontend service inside a container
+// +up
+func (m *Frontend) FrontendService(ctx context.Context) (*dagger.Service, error) {
+	plt, err := dag.DefaultPlatform(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	ctr, err := m.build(ctx, plt, localBackendPort)
+	if err != nil {
+		return nil, fmt.Errorf("error building frontend: %w", err)
+	}
+
+	return ctr.
+		WithExposedPort(localFrontendPort).
+		AsService(dagger.ContainerAsServiceOpts{UseEntrypoint: true}), nil
+}


### PR DESCRIPTION
Introduce dagger services for simplified testing of the application. This only requires the user to run `dagger up` on their machine to test and run the application. This is a huge bonus for users who don't have node, and go toolchains installed on their machines.