### PR TITLE
🐛 Fix table rows to alternate between primary and secondary colour

### DIFF
--- a/backend/shopping/assets/table.css
+++ b/backend/shopping/assets/table.css
@@ -17,7 +17,7 @@ tr {
     background-color: rgb(85, 0, 255);
 }
 
-tr:nth-child(2) {
+tr:nth-child(even) {
     background-color: rgb(105, 44, 226);
 }
 


### PR DESCRIPTION
Fix table rows to alternate between primary and secondary colour so that the design adheres to the intended alternating row style.