### PR TITLE
🔥 Remove dagger scripts to avoid maintenance.

### DIFF
--- a/backend/scripts/generate-protos.dsh
+++ b/backend/scripts/generate-protos.dsh
@@ -1,3 +1,0 @@
-#!/usr/bin/env dagger
-
-. | generate-protos | export ./gen

--- a/backend/scripts/generate-sqlc.dsh
+++ b/backend/scripts/generate-sqlc.dsh
@@ -1,3 +1,0 @@
-#!/usr/bin/env dagger
-
-. | generate-sqlc | export ./gensql

--- a/backend/scripts/publish.dsh
+++ b/backend/scripts/publish.dsh
@@ -1,3 +1,0 @@
-#!/usr/bin/env dagger
-
-. | publish-linux-arm-64 $(secret env://GH_API_KEY)

--- a/frontend/scripts/publish.dsh
+++ b/frontend/scripts/publish.dsh
@@ -1,3 +1,0 @@
-#!/usr/bin/env dagger
-
-. | publish-linux-arm-64 $(secret env://GH_API_KEY)

--- a/scripts/deploy.dsh
+++ b/scripts/deploy.dsh
@@ -1,3 +1,0 @@
-#!/usr/bin/env dagger
-
-. | deploy $(secret file://local/GH_API_KEY) $(secret file://local/kubecfg.yaml)


### PR DESCRIPTION
Remove dagger scripts to avoid maintenance. These scripts are either obsolete ( `dagger generate` superseds generate scripts ) or unnecessary ( publish/deploy functions can simply be called over the command line ). Removing these scripts avoids the need to maintain them,
reducing toil.