### PR TITLE
🔒 Introduce claude permission settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(./local/**)",
+      "Read(./backend/local/**)"
+    ]
+  }
+}


### PR DESCRIPTION
Introduce claude permission settings to prevent secret files
(e.g. SSH keys, kubeconfig) stored in local directories from
being leaked into the claude context.