### PR TITLE
🔧 Set frontend dev port to 3000

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,5 +3,8 @@ import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit(),tailwindcss()]
+	plugins: [sveltekit(),tailwindcss()],
+	server: {
+		port: 3000,
+	}
 });


### PR DESCRIPTION
 Set frontend dev port to 3000 to align with the same port used by the dagger service. 