### PR TITLE
🔥 Remove amd64 image builds from frontend and backend

### DIFF
--- a/backend/.dagger/main.go
+++ b/backend/.dagger/main.go
@@ -44,7 +44,7 @@ func (m *Backend) Publish(
 	tag string,
 	registryPassword *dagger.Secret,
 ) error {
-	plats := []dagger.Platform{"linux/arm64", "linux/amd64"}
+	plats := []dagger.Platform{"linux/arm64"}
 
 	ctrs := make([]*dagger.Container, len(plats))
 

--- a/backend/.dagger/migrate_image.go
+++ b/backend/.dagger/migrate_image.go
@@ -15,7 +15,7 @@ func (m *Backend) PublishMigrateImage(
 	tag string,
 	registryPassword *dagger.Secret,
 ) error {
-	plats := []dagger.Platform{"linux/arm64", "linux/amd64"}
+	plats := []dagger.Platform{"linux/arm64"}
 
 	toSql := m.RootSrc.File(schemaPath)
 

--- a/frontend/.dagger/main.go
+++ b/frontend/.dagger/main.go
@@ -98,7 +98,7 @@ func (m *Frontend) Publish(
 	tag string,
 	registryPassword *dagger.Secret,
 ) error {
-	plats := []dagger.Platform{"linux/arm64", "linux/amd64"}
+	plats := []dagger.Platform{"linux/arm64"}
 
 	ctrs := make([]*dagger.Container, len(plats))
 


### PR DESCRIPTION
 Remove amd64 from the platform list in the frontend and backend dagger modules so that only arm64 images are built and published. 