### PR TITLE
💄 Improve column sizing on tables

### DIFF
--- a/backend/shopping/assets/maintw.css
+++ b/backend/shopping/assets/maintw.css
@@ -262,8 +262,8 @@
   .flex-shrink-1 {
     flex-shrink: 1;
   }
-  .table-fixed {
-    table-layout: fixed;
+  .flex-grow-1 {
+    flex-grow: 1;
   }
   .border-separate {
     border-collapse: separate;

--- a/backend/shopping/render/base.templ
+++ b/backend/shopping/render/base.templ
@@ -26,7 +26,7 @@ templ base(pageContext page.Context) {
 						<div class="hidden sm:block w-40 flex-shrink-0">
 							@components.Nav(pageContext)
 						</div>
-						<div class="flex flex-shrink-1 flex-basis-0 min-w-0 flex-col">
+						<div class="flex flex-grow-1 flex-shrink-1 flex-basis-0 min-w-0 flex-col">
 							{ children... }
 						</div>
 					</div>

--- a/backend/shopping/render/base_templ.go
+++ b/backend/shopping/render/base_templ.go
@@ -50,7 +50,7 @@ func base(pageContext page.Context) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><div class=\"flex flex-shrink-1 flex-basis-0 min-w-0 flex-col\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</div><div class=\"flex flex-grow-1 flex-shrink-1 flex-basis-0 min-w-0 flex-col\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/backend/shopping/render/components/table.templ
+++ b/backend/shopping/render/components/table.templ
@@ -1,7 +1,7 @@
 package components
 
 templ Table() {
-    <table class="w-full table-fixed border-separate border-spacing-0 rounded-lg shadow-md sm:text-base text-sm">
+    <table class="w-full border-separate border-spacing-0 rounded-lg shadow-md sm:text-base text-sm">
         <tbody>
             {children...}
         </tbody>

--- a/backend/shopping/render/components/table_templ.go
+++ b/backend/shopping/render/components/table_templ.go
@@ -29,7 +29,7 @@ func Table() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<table class=\"w-full table-fixed border-separate border-spacing-0 rounded-lg shadow-md sm:text-base text-sm\"><tbody>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<table class=\"w-full border-separate border-spacing-0 rounded-lg shadow-md sm:text-base text-sm\"><tbody>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/frontend/src/components/table.svelte
+++ b/frontend/src/components/table.svelte
@@ -4,7 +4,7 @@
         classes?: string,
     } = $props();
 </script>
-<table class="{classes} w-full table-fixed border-separate border-spacing-0 rounded-lg shadow-md sm:text-base text-sm">
+<table class="{classes} w-full border-separate border-spacing-0 rounded-lg shadow-md sm:text-base text-sm">
     <tbody>
         {@render children()}
     </tbody>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -13,7 +13,7 @@
 			<div class="hidden sm:block w-40 flex-shrink-0">
 				<Nav />
 			</div>
-			<div class="flex flex-shrink-1 flex-basis-0 min-w-0 flex-col">
+			<div class="flex flex-grow-1 flex-shrink-1 flex-basis-0 min-w-0 flex-col">
 				{@render children()}
 			</div>
 		</div>


### PR DESCRIPTION
 Improve column sizing on tables by removing the `table-fixed` from all tables, allowing columns to take the size required by their contents. This improves table readability on smaller devices and also just looks nicer. 
 
 Before:
<img width="856" height="429" alt="before" src="https://github.com/user-attachments/assets/69304fe4-97b9-4fef-8087-1589dd08da80" />

After:
<img width="849" height="433" alt="after" src="https://github.com/user-attachments/assets/04095dc3-a875-4ddd-84f0-5e4584da00a9" />

