### PR TITLE
🐛 Fix body from overflowing

### DIFF
--- a/backend/shopping/assets/maintw.css
+++ b/backend/shopping/assets/maintw.css
@@ -217,9 +217,6 @@
   .mt-5 {
     margin-top: calc(var(--spacing) * 5);
   }
-  .mt-10 {
-    margin-top: calc(var(--spacing) * 10);
-  }
   .mb-2 {
     margin-bottom: calc(var(--spacing) * 2);
   }
@@ -348,8 +345,11 @@
   .py-10 {
     padding-block: calc(var(--spacing) * 10);
   }
-  .pt-16 {
-    padding-top: calc(var(--spacing) * 16);
+  .pt-26 {
+    padding-top: calc(var(--spacing) * 26);
+  }
+  .pb-10 {
+    padding-bottom: calc(var(--spacing) * 10);
   }
   .text-left {
     text-align: left;
@@ -486,11 +486,6 @@
       left: calc(var(--spacing) * 0);
     }
   }
-  .sm\:mt-0 {
-    @media (width >= 40rem) {
-      margin-top: calc(var(--spacing) * 0);
-    }
-  }
   .sm\:block {
     @media (width >= 40rem) {
       display: block;
@@ -499,6 +494,11 @@
   .sm\:hidden {
     @media (width >= 40rem) {
       display: none;
+    }
+  }
+  .sm\:pt-16 {
+    @media (width >= 40rem) {
+      padding-top: calc(var(--spacing) * 16);
     }
   }
   .sm\:pl-4 {

--- a/backend/shopping/render/base.templ
+++ b/backend/shopping/render/base.templ
@@ -21,8 +21,8 @@ templ base(pageContext page.Context) {
 		<body>
 			<div class="flex flex-col bg-gray-100">
 				@components.MenuBar(pageContext)
-				<div class="h-screen overflow-y-auto mt-10 sm:mt-0">
-					<div class="flex flex-row pt-16 px-8">
+				<div class="h-screen overflow-y-auto pt-26 sm:pt-16 pb-10">
+					<div class="flex flex-row px-8">
 						<div class="hidden sm:block w-40 flex-shrink-0">
 							@components.Nav(pageContext)
 						</div>

--- a/backend/shopping/render/base_templ.go
+++ b/backend/shopping/render/base_templ.go
@@ -42,7 +42,7 @@ func base(pageContext page.Context) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"h-screen overflow-y-auto mt-10 sm:mt-0\"><div class=\"flex flex-row pt-16 px-8\"><div class=\"hidden sm:block w-40 flex-shrink-0\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"h-screen overflow-y-auto pt-26 sm:pt-16 pb-10\"><div class=\"flex flex-row px-8\"><div class=\"hidden sm:block w-40 flex-shrink-0\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -8,8 +8,8 @@
 
 <div class="flex flex-col bg-gray-100">
 	<MenuBar></MenuBar>
-	<div class="h-screen overflow-y-auto mt-10 sm:mt-0">
-		<div class="flex flex-row pt-16 px-8">
+	<div class="h-screen overflow-y-auto pt-26 sm:pt-16 pb-10">
+		<div class="flex flex-row px-8">
 			<div class="hidden sm:block w-40 flex-shrink-0">
 				<Nav />
 			</div>


### PR DESCRIPTION
 Fix body to stop it from overflowing the html container. At the same time the padding is consolidated from a child div into its parent for simplicity. 