### PR TITLE
🐛 Fix menu bar height issue

### DIFF
--- a/backend/shopping/render/components/menu-bar.templ
+++ b/backend/shopping/render/components/menu-bar.templ
@@ -5,7 +5,7 @@ import (
 )
 
 templ MenuBar(pageContext page.Context) {
-    <div class="sm:hidden absolute top-0 left-0 p-5 z-5 shadow-md w-full bg-gray-100">
+    <div class="sm:hidden flex absolute top-0 left-0 p-5 z-5 shadow-md w-full bg-gray-100">
         <button class="cursor-pointer" hx-on:click={ templ.JSFuncCall("showMenu") }>
             <img src="/assets/menu.svg" alt="menu" height="20" width="20" />
         </button>

--- a/backend/shopping/render/components/menu-bar_templ.go
+++ b/backend/shopping/render/components/menu-bar_templ.go
@@ -33,7 +33,7 @@ func MenuBar(pageContext page.Context) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"sm:hidden absolute top-0 left-0 p-5 z-5 shadow-md w-full bg-gray-100\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"sm:hidden flex absolute top-0 left-0 p-5 z-5 shadow-md w-full bg-gray-100\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/frontend/src/routes/MenuBar.svelte
+++ b/frontend/src/routes/MenuBar.svelte
@@ -11,7 +11,7 @@
     expanded = false
   }
 </script>
-<div class="sm:hidden absolute top-0 left-0 p-5 z-5 shadow-md w-full bg-gray-100">
+<div class="sm:hidden flex absolute top-0 left-0 p-5 z-5 shadow-md w-full bg-gray-100">
     <button class="cursor-pointer" onclick={() => show()}>
 	    <img src={menuSvg} alt="menu" height="20" width="20" />
     </button>


### PR DESCRIPTION
 Fix menu bar inconsistent height issue, where 6 pixels were being added and the menu bar wasn't considering the child content height which didn't need these extra 6 pixels. 