### PR TITLE
💄 Reduce spacing on h1

### DIFF
--- a/backend/shopping/assets/maintw.css
+++ b/backend/shopping/assets/maintw.css
@@ -220,6 +220,9 @@
   .mb-2 {
     margin-bottom: calc(var(--spacing) * 2);
   }
+  .mb-5 {
+    margin-bottom: calc(var(--spacing) * 5);
+  }
   .ml-5 {
     margin-left: calc(var(--spacing) * 5);
   }
@@ -341,9 +344,6 @@
   }
   .py-4 {
     padding-block: calc(var(--spacing) * 4);
-  }
-  .py-10 {
-    padding-block: calc(var(--spacing) * 10);
   }
   .pt-26 {
     padding-top: calc(var(--spacing) * 26);

--- a/backend/shopping/render/components/h1.templ
+++ b/backend/shopping/render/components/h1.templ
@@ -1,5 +1,5 @@
 package components
 
 templ H1(title string) {
-    <h1 class="font-normal text-3xl text-left sm:text-4xl py-10 font-sans">{title}</h1>
+    <h1 class="font-normal text-3xl text-left sm:text-4xl mb-5 font-sans">{title}</h1>
 }

--- a/backend/shopping/render/components/h1_templ.go
+++ b/backend/shopping/render/components/h1_templ.go
@@ -29,14 +29,14 @@ func H1(title string) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<h1 class=\"font-normal text-3xl text-left sm:text-4xl py-10 font-sans\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<h1 class=\"font-normal text-3xl text-left sm:text-4xl mb-5 font-sans\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shopping/render/components/h1.templ`, Line: 4, Col: 81}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `shopping/render/components/h1.templ`, Line: 4, Col: 80}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {

--- a/frontend/src/components/h1.svelte
+++ b/frontend/src/components/h1.svelte
@@ -4,4 +4,4 @@
         classes?: string,
     } = $props();
 </script>
-<h1 class="{classes} font-normal text-3xl text-left sm:text-4xl py-10 font-sans">{@render children()}</h1>
+<h1 class="{classes} font-normal text-3xl text-left sm:text-4xl mb-5 font-sans">{@render children()}</h1>


### PR DESCRIPTION
 Reduce spacing the h1 element and only apply to the bottom. Use margin instead of padding. 