### PR TITLE
🔧 Add Read and git permissions to Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,9 @@
 {
   "permissions": {
     "allow": [
-      "Bash(go run ./scripts/raise-pr/raise-pr.go)"
+      "Bash(go run ./scripts/raise-pr/raise-pr.go)",
+      "Read(*)",
+      "Bash(git *)"
     ],
     "deny": [
       "Read(./local/**)",

--- a/.claude/skills/codebase/SKILL.md
+++ b/.claude/skills/codebase/SKILL.md
@@ -30,3 +30,11 @@ IMPORTANT: Dont update generated code directly. Use `dagger generate -y` if you 
 
 - Directories: `**/.dagger`
 - Load the dagger skill when working with these.
+
+## Notes on generating code
+
+Always run `dagger generate -y` from either the `frontend` or `backend` directory, not from the repo root.
+
+**Why:** Running from the root generates files in the wrong locations (stray directories like genpb/, gensql/, shopping/, src/ appear at the repo root).
+
+**How to apply:** `cd backend && dagger generate -y` or `cd frontend && dagger generate -y` depending on what changed.


### PR DESCRIPTION
 Add Read(*) and Bash(git *) to the Claude Code permissions allowlist to reduce repetitive permission prompts and enhance the experience when using agentic coding agents such as Claude Code. 