### PR TITLE
🎨 Seperate backend and frontend ghcr repos

### DIFF
--- a/backend/.dagger/main.go
+++ b/backend/.dagger/main.go
@@ -69,7 +69,7 @@ func (m *Backend) Publish(
 
 	_, err := dag.Container().
 		WithRegistryAuth("ghcr.io", "USERNAME", registryPassword).
-		Publish(ctx, fmt.Sprintf("ghcr.io/chrisjpalmer/shoppinglist:backend-%s", tag), dagger.ContainerPublishOpts{
+		Publish(ctx, fmt.Sprintf("ghcr.io/chrisjpalmer/shoppinglist/backend:%s", tag), dagger.ContainerPublishOpts{
 			PlatformVariants: ctrs,
 		})
 

--- a/backend/helm/templates/deployment.yaml
+++ b/backend/helm/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       initContainers:
         - name: migrate
-          image: "ghcr.io/chrisjpalmer/shoppinglist:backend-{{ .Values.image.tag }}"
+          image: "ghcr.io/chrisjpalmer/shoppinglist/backend:{{ .Values.image.tag }}"
           volumeMounts:
             - mountPath: /app/local
               name: db
@@ -27,7 +27,7 @@ spec:
           command: ["/migrations/entrypoint.sh"]
       containers:
         - name: backend
-          image: "ghcr.io/chrisjpalmer/shoppinglist:backend-{{ .Values.image.tag }}"
+          image: "ghcr.io/chrisjpalmer/shoppinglist/backend:{{ .Values.image.tag }}"
           ports:
             - name: http
               containerPort: 8080

--- a/frontend/.dagger/main.go
+++ b/frontend/.dagger/main.go
@@ -116,7 +116,7 @@ func (m *Frontend) Publish(
 
 	_, err := dag.Container().
 		WithRegistryAuth("ghcr.io", "USERNAME", registryPassword).
-		Publish(ctx, fmt.Sprintf("ghcr.io/chrisjpalmer/shoppinglist:frontend-%s", tag), dagger.ContainerPublishOpts{
+		Publish(ctx, fmt.Sprintf("ghcr.io/chrisjpalmer/shoppinglist/frontend:%s", tag), dagger.ContainerPublishOpts{
 			PlatformVariants: ctrs,
 		})
 

--- a/frontend/helm/templates/deployment.yaml
+++ b/frontend/helm/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: frontend
-          image: "ghcr.io/chrisjpalmer/shoppinglist:frontend-{{ .Values.image.tag }}"
+          image: "ghcr.io/chrisjpalmer/shoppinglist/frontend:{{ .Values.image.tag }}"
           ports:
             - name: http
               containerPort: 3000


### PR DESCRIPTION
 Seperate backend and frontend ghcr repos rather than maintaining seperate tags under the same repo. This is the right way to use ghcr images, and was done the other way just because it was simpler at the time. 