### PR TITLE
👷 Re-enable amd64 builds for railway

### DIFF
--- a/backend/.dagger/main.go
+++ b/backend/.dagger/main.go
@@ -44,7 +44,7 @@ func (m *Backend) Publish(
 	tag string,
 	registryPassword *dagger.Secret,
 ) error {
-	plats := []dagger.Platform{"linux/arm64"}
+	plats := []dagger.Platform{"linux/arm64", "linux/amd64"}
 
 	ctrs := make([]*dagger.Container, len(plats))
 

--- a/frontend/.dagger/main.go
+++ b/frontend/.dagger/main.go
@@ -91,7 +91,7 @@ func (m *Frontend) Publish(
 	tag string,
 	registryPassword *dagger.Secret,
 ) error {
-	plats := []dagger.Platform{"linux/arm64"}
+	plats := []dagger.Platform{"linux/arm64", "linux/amd64"}
 
 	ctrs := make([]*dagger.Container, len(plats))
 


### PR DESCRIPTION
 Re-enable amd64 builds for railway since railway by default attempts to deploy this architecture. 