### PR TITLE
✨ Move to railway preview environment

### DIFF
--- a/.dagger/main.go
+++ b/.dagger/main.go
@@ -57,10 +57,6 @@ func (m *Shoppinglist) BuildAndDeploy(
 		return fmt.Errorf("error while deploying to kubeEnv1: %w", err)
 	}
 
-	if err := m.Deploy(ctx, "env2", tag, kubeEnv2, "http://100.49.208.199:30000/", "http://100.49.208.199:30001/api", "http://100.49.208.199:30001/shopping"); err != nil {
-		return fmt.Errorf("error while deploying to kubeEnv2: %w", err)
-	}
-
 	return nil
 }
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ A pet project to keep track of my shopping!
 Originally there was only the meal planning site ( written in svelte ).
 A new shopping site is being built out in htmx / gotempl for a bit of fun.
 
-A preview version of the sites are available here (these are deployed to for every commit to master):
+A preview version of the sites is hosted on railway:
 
-- Meal Planning Site: http://100.49.208.199:30000/
-- Shopping Site: http://100.49.208.199:30001/shopping
+- Meal Planning Site: https://frontend-production-4312.up.railway.app/
+- Shopping Site: https://backend-production-28fe5.up.railway.app/shopping
+
+The full project and its [settings can be viewed here](https://railway.com/project/8c0aadfe-273e-469b-a372-ad00f4f5b025)
 
 ## Running the project
 


### PR DESCRIPTION
 Move to a railway based preview environment. Railway is much cheaper than the cheapest AWS instance, therefore the preview environment is being moved there. 