### PR TITLE
🐛 Fix missing /shopping prefix in want page save button

### DIFF
--- a/backend/shopping/render/want.templ
+++ b/backend/shopping/render/want.templ
@@ -50,7 +50,7 @@ templ WantPage(pageContext page.Context, wantItems []page.WantItem) {
 			@components.Button(components.ButtonOpts{
 				ID: "save-button", 
 				Title: "Save", 
-				HxPost: "/want?fragment=content", 
+				HxPost: "/shopping/want?fragment=content",
 				HxInclude: ".col-override", 
 				HxTarget: "#content", 
 				HxOnClick: "setClean", 

--- a/backend/shopping/render/want_templ.go
+++ b/backend/shopping/render/want_templ.go
@@ -417,7 +417,7 @@ func WantPage(pageContext page.Context, wantItems []page.WantItem) templ.Compone
 				templ_7745c5c3_Err = components.Button(components.ButtonOpts{
 					ID:        "save-button",
 					Title:     "Save",
-					HxPost:    "/want?fragment=content",
+					HxPost:    "/shopping/want?fragment=content",
 					HxInclude: ".col-override",
 					HxTarget:  "#content",
 					HxOnClick: "setClean",


### PR DESCRIPTION
 Fix missing /shopping prefix in the HxPost attribute of the save button on the want page, causing page refresh to fail after saving. 