### PR TITLE
✨ Make the shop page the default page

### DIFF
--- a/backend/shopping/render/components/nav.templ
+++ b/backend/shopping/render/components/nav.templ
@@ -9,9 +9,9 @@ import (
 templ Nav(pageContext page.Context) {
     <nav>
         <ul>
-            @Li(pageContext, "Want", "/shopping/want")
-            @Li(pageContext, "Got", "/shopping/got")
             @Li(pageContext, "Shop", "/shopping/shop")
+            @Li(pageContext, "Got", "/shopping/got")
+            @Li(pageContext, "Want", "/shopping/want")
             @Li(pageContext, "Planning", pageContext.PlanningSiteURL, LiOpts{
                 Image: &Image{
                     Source: "/shopping/assets/exit.svg",

--- a/backend/shopping/render/components/nav_templ.go
+++ b/backend/shopping/render/components/nav_templ.go
@@ -40,7 +40,7 @@ func Nav(pageContext page.Context) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Li(pageContext, "Want", "/shopping/want").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Li(pageContext, "Shop", "/shopping/shop").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -48,7 +48,7 @@ func Nav(pageContext page.Context) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Li(pageContext, "Shop", "/shopping/shop").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Li(pageContext, "Want", "/shopping/want").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/backend/shopping/server.go
+++ b/backend/shopping/server.go
@@ -45,7 +45,7 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux) {
 }
 
 func handleRootPage(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add("Location", "/shopping/want")
+	w.Header().Add("Location", "/shopping/shop")
 	w.WriteHeader(http.StatusFound)
 }
 


### PR DESCRIPTION
 Make the shop page the default page since it is the primary function of the shopping site. The order of the pages is also reversed, since users rarely will need the `want` page, but will regularly use the `got` and `shop` pages. 