### PR TITLE
💄 Improve layout on mobile displays

### DIFF
--- a/backend/shopping/assets/maintw.css
+++ b/backend/shopping/assets/maintw.css
@@ -358,8 +358,8 @@
   .px-4 {
     padding-inline: calc(var(--spacing) * 4);
   }
-  .px-8 {
-    padding-inline: calc(var(--spacing) * 8);
+  .px-6 {
+    padding-inline: calc(var(--spacing) * 6);
   }
   .py-1 {
     padding-block: calc(var(--spacing) * 1);
@@ -370,14 +370,14 @@
   .py-4 {
     padding-block: calc(var(--spacing) * 4);
   }
-  .pt-26 {
-    padding-top: calc(var(--spacing) * 26);
+  .pt-22 {
+    padding-top: calc(var(--spacing) * 22);
   }
   .pr-2 {
     padding-right: calc(var(--spacing) * 2);
   }
-  .pb-10 {
-    padding-bottom: calc(var(--spacing) * 10);
+  .pb-6 {
+    padding-bottom: calc(var(--spacing) * 6);
   }
   .text-left {
     text-align: left;
@@ -536,9 +536,19 @@
       display: none;
     }
   }
+  .sm\:px-8 {
+    @media (width >= 40rem) {
+      padding-inline: calc(var(--spacing) * 8);
+    }
+  }
   .sm\:pt-16 {
     @media (width >= 40rem) {
       padding-top: calc(var(--spacing) * 16);
+    }
+  }
+  .sm\:pb-10 {
+    @media (width >= 40rem) {
+      padding-bottom: calc(var(--spacing) * 10);
     }
   }
   .sm\:pl-4 {

--- a/backend/shopping/render/base.templ
+++ b/backend/shopping/render/base.templ
@@ -21,8 +21,8 @@ templ base(pageContext page.Context) {
 		<body class="h-full">
 			<div class="h-full flex flex-col bg-gray-100">
 				@components.MenuBar(pageContext)
-				<div class="h-full overflow-hidden pt-26 sm:pt-16 pb-10">
-					<div class="h-full flex flex-row px-8">
+				<div class="h-full overflow-hidden pt-22 pb-6 sm:pt-16 sm:pb-10">
+					<div class="h-full flex flex-row px-6 sm:px-8">
 						<div class="hidden sm:block w-40 flex-shrink-0">
 							@components.Nav(pageContext)
 						</div>

--- a/backend/shopping/render/base_templ.go
+++ b/backend/shopping/render/base_templ.go
@@ -42,7 +42,7 @@ func base(pageContext page.Context) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"h-full overflow-hidden pt-26 sm:pt-16 pb-10\"><div class=\"h-full flex flex-row px-8\"><div class=\"hidden sm:block w-40 flex-shrink-0\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"h-full overflow-hidden pt-22 pb-6 sm:pt-16 sm:pb-10\"><div class=\"h-full flex flex-row px-6 sm:px-8\"><div class=\"hidden sm:block w-40 flex-shrink-0\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -8,8 +8,8 @@
 
 <div class="h-full flex flex-col bg-gray-100">
 	<MenuBar></MenuBar>
-	<div class="h-full overflow-hidden pt-26 sm:pt-16 pb-10">
-		<div class="h-full flex flex-row px-8">
+	<div class="h-full overflow-hidden pt-22 pb-6 sm:pt-16 sm:pb-10">
+		<div class="h-full flex flex-row px-6 sm:px-8">
 			<div class="hidden sm:block w-40 flex-shrink-0">
 				<Nav />
 			</div>

--- a/frontend/src/routes/recipies/+page.svelte
+++ b/frontend/src/routes/recipies/+page.svelte
@@ -43,7 +43,7 @@
 
 <div class="flex flex-row flex-wrap w-full justify-center overflow-y-auto h-full">
 	{#each meals as m (m.id)}
-	<a href="/recipies/{m.id}" class="flex flex-col justify-end relative overflow-hidden items-center w-25 h-25 m-1 sm:w-50 sm:h-50 sm:m-4 rounded-md bg-white shadow-md">
+	<a href="/recipies/{m.id}" class="flex flex-col justify-end relative overflow-hidden items-center w-30 h-30 m-1 sm:w-50 sm:h-50 sm:m-4 rounded-md bg-white shadow-md">
 		<p class="bg-white/70 z-2 px-3 font-medium w-full text-center sm:text-base text-xs">{m.name}</p>
 		<div class="absolute top-0 left-0 w-full h-full bg-cover" style="background-image: url({m.previewImageUrl || '/ramen.svg'})"></div>
 	</a>


### PR DESCRIPTION
 Improve layout on mobile displays by reducing padding and increasing the sizes of the recipe thumbnails. This maximises the use of space on a mobile device. 