### PR TITLE
✨ Add meal category for baby food

### DIFF
--- a/backend/api/plan.go
+++ b/backend/api/plan.go
@@ -176,7 +176,10 @@ func emptyPlan() genpb.Plan {
 		days = append(days, &genpb.Day{
 			CategoryMeals: []*genpb.CategoryMeal{
 				// 0 = lunch, 1 = dinner, 2 = snack
-				{Category: genpb.Category_CATEGORY_LUNCH}, {Category: genpb.Category_CATEGORY_DINNER}, {Category: genpb.Category_CATEGORY_SNACK},
+				{Category: genpb.Category_CATEGORY_LUNCH},
+				{Category: genpb.Category_CATEGORY_DINNER},
+				{Category: genpb.Category_CATEGORY_SNACK},
+				{Category: genpb.Category_CATEGORY_BABY},
 			},
 		})
 	}

--- a/backend/genpb/plan.pb.go
+++ b/backend/genpb/plan.pb.go
@@ -27,6 +27,7 @@ const (
 	Category_CATEGORY_LUNCH  Category = 0
 	Category_CATEGORY_DINNER Category = 1
 	Category_CATEGORY_SNACK  Category = 2
+	Category_CATEGORY_BABY   Category = 3
 )
 
 // Enum value maps for Category.
@@ -35,11 +36,13 @@ var (
 		0: "CATEGORY_LUNCH",
 		1: "CATEGORY_DINNER",
 		2: "CATEGORY_SNACK",
+		3: "CATEGORY_BABY",
 	}
 	Category_value = map[string]int32{
 		"CATEGORY_LUNCH":  0,
 		"CATEGORY_DINNER": 1,
 		"CATEGORY_SNACK":  2,
+		"CATEGORY_BABY":   3,
 	}
 )
 
@@ -269,11 +272,12 @@ const file_plan_proto_rawDesc = "" +
 	"\bcategory\x18\x01 \x01(\x0e2\t.CategoryR\bcategory\x12\x17\n" +
 	"\ameal_id\x18\x02 \x01(\x03R\x06mealId\"D\n" +
 	"\vPlanSummary\x125\n" +
-	"\x0eingredient_ref\x18\x01 \x03(\v2\x0e.IngredientRefR\ringredientRef*G\n" +
+	"\x0eingredient_ref\x18\x01 \x03(\v2\x0e.IngredientRefR\ringredientRef*Z\n" +
 	"\bCategory\x12\x12\n" +
 	"\x0eCATEGORY_LUNCH\x10\x00\x12\x13\n" +
 	"\x0fCATEGORY_DINNER\x10\x01\x12\x12\n" +
-	"\x0eCATEGORY_SNACK\x10\x02BAB\tPlanProtoP\x01Z2github.com/chrisjpalmer/shoppinglist/backend/genpbb\x06proto3"
+	"\x0eCATEGORY_SNACK\x10\x02\x12\x11\n" +
+	"\rCATEGORY_BABY\x10\x03BAB\tPlanProtoP\x01Z2github.com/chrisjpalmer/shoppinglist/backend/genpbb\x06proto3"
 
 var (
 	file_plan_proto_rawDescOnce sync.Once

--- a/backend/proto/plan.proto
+++ b/backend/proto/plan.proto
@@ -20,6 +20,7 @@ enum Category {
   CATEGORY_LUNCH = 0;
   CATEGORY_DINNER = 1;
   CATEGORY_SNACK = 2;
+  CATEGORY_BABY = 3;
 }
 
 message PlanSummary {

--- a/frontend/src/gen/plan_pb.ts
+++ b/frontend/src/gen/plan_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file plan.proto.
  */
 export const file_plan: GenFile = /*@__PURE__*/
-  fileDesc("CgpwbGFuLnByb3RvIhoKBFBsYW4SEgoEZGF5cxgBIAMoCzIELkRheSIsCgNEYXkSJQoOY2F0ZWdvcnlfbWVhbHMYASADKAsyDS5DYXRlZ29yeU1lYWwiPAoMQ2F0ZWdvcnlNZWFsEhsKCGNhdGVnb3J5GAEgASgOMgkuQ2F0ZWdvcnkSDwoHbWVhbF9pZBgCIAEoAyI1CgtQbGFuU3VtbWFyeRImCg5pbmdyZWRpZW50X3JlZhgBIAMoCzIOLkluZ3JlZGllbnRSZWYqRwoIQ2F0ZWdvcnkSEgoOQ0FURUdPUllfTFVOQ0gQABITCg9DQVRFR09SWV9ESU5ORVIQARISCg5DQVRFR09SWV9TTkFDSxACYgZwcm90bzM", [file_meal]);
+  fileDesc("CgpwbGFuLnByb3RvIhoKBFBsYW4SEgoEZGF5cxgBIAMoCzIELkRheSIsCgNEYXkSJQoOY2F0ZWdvcnlfbWVhbHMYASADKAsyDS5DYXRlZ29yeU1lYWwiPAoMQ2F0ZWdvcnlNZWFsEhsKCGNhdGVnb3J5GAEgASgOMgkuQ2F0ZWdvcnkSDwoHbWVhbF9pZBgCIAEoAyI1CgtQbGFuU3VtbWFyeRImCg5pbmdyZWRpZW50X3JlZhgBIAMoCzIOLkluZ3JlZGllbnRSZWYqWgoIQ2F0ZWdvcnkSEgoOQ0FURUdPUllfTFVOQ0gQABITCg9DQVRFR09SWV9ESU5ORVIQARISCg5DQVRFR09SWV9TTkFDSxACEhEKDUNBVEVHT1JZX0JBQlkQA2IGcHJvdG8z", [file_meal]);
 
 /**
  * @generated from message Plan
@@ -105,6 +105,11 @@ export enum Category {
    * @generated from enum value: CATEGORY_SNACK = 2;
    */
   SNACK = 2,
+
+  /**
+   * @generated from enum value: CATEGORY_BABY = 3;
+   */
+  BABY = 3,
 }
 
 /**

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -17,6 +17,7 @@
 		Category.LUNCH,
 		Category.DINNER,
 		Category.SNACK,
+		Category.BABY,
 	]
 
 	const days = [
@@ -44,6 +45,8 @@
 		// plan
 		const planRs = await client.getPlan({})
 		plan = <Plan> planRs.plan
+
+		normalizePlan(plan)
 
 		// all meals
 		const mealRs = await client.getMeals({})
@@ -92,6 +95,24 @@
 		refresh()
 	}
 
+	function normalizePlan(p:Plan) {
+		for (let day of p.days) {
+			for(let c = 0; c < categories.length; c++) {
+
+				// fill category
+				if (day.categoryMeals.length < (c+1)) {
+					console.log(`filled category ${c}`)
+
+					day.categoryMeals.push({
+						category: categories[c],
+						mealId: 0n,
+						$typeName: 'CategoryMeal'
+					})
+				}
+			}
+		}
+	}
+
 	refresh()
 	
 </script>
@@ -110,7 +131,7 @@
 			{/each}
 		</TrHeader>
 		{#each categories as category}
-		<Tr classes="h-40">
+		<Tr classes="h-25">
 			<Td classes="font-bold">{Category[category]}</Td>
 			{#each days as day, i}
 			<Td>


### PR DESCRIPTION
 Add a meal category for baby food to allow the user to plan for their baby (hehe). A `normalizePlan()` function is added in the frontend to allow the plan to have the expected categories from the frontend, so that data binding works. 